### PR TITLE
feat: add directory import support and release v0.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle-docs-generator",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "A CLI tool that generates DBML files from Drizzle ORM schema definitions.",
   "keywords": [
     "cli",


### PR DESCRIPTION
## Summary

Release v0.1.2 with directory import support for schema files.

## What's New in v0.1.2

### 🎉 New Features

- **Directory Import Support**: You can now specify a directory containing schema files instead of individual files
  ```bash
  # Import all schema files from directory
  drizzle-docs generate ./src/schema/ -d postgresql
  ```

### 🔧 Improvements

- Better error messages with helpful tips for module resolution issues
- Recursive directory scanning for TypeScript/JavaScript files
- Automatic merging of multiple schema modules

### 🐛 Fixes

- Resolves "Directory import is not supported resolving ES modules" error
- Better error handling for empty directories and non-existent paths

## Usage Examples

```bash
# Directory import (NEW!)
drizzle-docs generate ./src/schema/ -d postgresql

# Single file (still works)
drizzle-docs generate ./src/schema/users.ts -d postgresql

# With output file
drizzle-docs generate ./src/schema/ -o docs.dbml -d postgresql
```

## Test Plan

- [x] All unit tests pass (90 tests)
- [x] All integration tests pass (37 tests including new directory tests)
- [x] Format, lint, and typecheck pass
- [x] Version bumped to 0.1.2

## Breaking Changes

None - fully backward compatible.