### PR TITLE
feat: implement MarkdownFormatter for tbls-style Markdown output

### DIFF
--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -3,3 +3,5 @@ export type { OutputFormatter, FormatterOptions } from "./types";
 
 // Implementations
 export { DbmlFormatter } from "./dbml";
+export { MarkdownFormatter } from "./markdown";
+export type { MarkdownFormatterOptions } from "./markdown";

--- a/src/formatter/markdown.test.ts
+++ b/src/formatter/markdown.test.ts
@@ -1,0 +1,983 @@
+import { describe, it, expect } from "vitest";
+import { MarkdownFormatter } from "./markdown";
+import type { IntermediateSchema } from "../types";
+
+describe("MarkdownFormatter", () => {
+  describe("format", () => {
+    it("should format a simple table", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+                autoIncrement: true,
+              },
+              {
+                name: "name",
+                type: "text",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+              {
+                name: "email",
+                type: "varchar(255)",
+                nullable: true,
+                primaryKey: false,
+                unique: true,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("# Tables");
+      expect(markdown).toContain("| [users](#users) | 3 |");
+      expect(markdown).toContain("## users");
+      expect(markdown).toContain("### Columns");
+      expect(markdown).toContain("| **id** | serial |");
+      expect(markdown).toContain("| name | text |");
+      expect(markdown).toContain("| email | varchar(255) |");
+    });
+
+    it("should format multiple tables", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "posts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "author_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("| [users](#users) | 1 |");
+      expect(markdown).toContain("| [posts](#posts) | 2 |");
+      expect(markdown).toContain("## users");
+      expect(markdown).toContain("## posts");
+    });
+
+    it("should format columns with default values", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "active",
+                type: "boolean",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+                defaultValue: "true",
+              },
+              {
+                name: "role",
+                type: "text",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+                defaultValue: "user",
+              },
+              {
+                name: "created_at",
+                type: "timestamp",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+                defaultValue: "now()",
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("`true`");
+      expect(markdown).toContain("`user`");
+      expect(markdown).toContain("`now()`");
+    });
+
+    it("should format empty schema", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("# Tables");
+      expect(markdown).toContain("No tables defined.");
+    });
+
+    it("should format indexes", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "email",
+                type: "varchar(255)",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [
+              {
+                name: "email_idx",
+                columns: ["email"],
+                unique: false,
+              },
+              {
+                name: "email_unique_idx",
+                columns: ["email"],
+                unique: true,
+              },
+            ],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("### Indexes");
+      expect(markdown).toContain("| email_idx | email | NO |");
+      expect(markdown).toContain("| email_unique_idx | email | YES |");
+    });
+
+    it("should format relations", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "posts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "author_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "posts",
+            fromColumns: ["author_id"],
+            toTable: "users",
+            toColumns: ["id"],
+            type: "many-to-one",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("### Relations");
+      expect(markdown).toContain("Many to One");
+    });
+
+    it("should format one-to-one relations", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "profile_id",
+                type: "integer",
+                nullable: true,
+                primaryKey: false,
+                unique: true,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "profiles",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "users",
+            fromColumns: ["profile_id"],
+            toTable: "profiles",
+            toColumns: ["id"],
+            type: "one-to-one",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("### Relations");
+      expect(markdown).toContain("One to One");
+    });
+
+    it("should format one-to-many relations", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "posts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "author_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "users",
+            fromColumns: ["id"],
+            toTable: "posts",
+            toColumns: ["author_id"],
+            type: "one-to-many",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("### Relations");
+      expect(markdown).toContain("One to Many");
+    });
+
+    it("should format PostgreSQL enums", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "status",
+                type: "user_status",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [
+          {
+            name: "user_status",
+            values: ["active", "inactive", "pending"],
+          },
+        ],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("# Enums");
+      expect(markdown).toContain("## user_status");
+      expect(markdown).toContain("| active |");
+      expect(markdown).toContain("| inactive |");
+      expect(markdown).toContain("| pending |");
+    });
+
+    it("should include table comments", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            comment: "User accounts table",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      // Comment in index table
+      expect(markdown).toContain("| [users](#users) | 1 | User accounts table |");
+      // Comment in table section
+      expect(markdown).toMatch(/## users\n\nUser accounts table/);
+    });
+
+    it("should include column comments", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+                comment: "Primary key",
+              },
+              {
+                name: "name",
+                type: "text",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+                comment: "User display name",
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("Primary key |");
+      expect(markdown).toContain("User display name |");
+    });
+
+    it("should escape pipe characters in comments", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            comment: "Table with | pipe character",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+                comment: "Column | with pipe",
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("Table with \\| pipe character");
+      expect(markdown).toContain("Column \\| with pipe");
+    });
+
+    it("should format constraints", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "email",
+                type: "varchar(255)",
+                nullable: false,
+                primaryKey: false,
+                unique: true,
+              },
+            ],
+            indexes: [],
+            constraints: [
+              {
+                name: "users_pkey",
+                type: "primary_key",
+                columns: ["id"],
+              },
+              {
+                name: "users_email_unique",
+                type: "unique",
+                columns: ["email"],
+              },
+            ],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("### Constraints");
+      expect(markdown).toContain("| users_pkey | PRIMARY KEY | (id) |");
+      expect(markdown).toContain("| users_email_unique | UNIQUE | (email) |");
+    });
+
+    it("should format foreign key constraints", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "posts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "author_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [
+              {
+                name: "posts_author_fkey",
+                type: "foreign_key",
+                columns: ["author_id"],
+                referencedTable: "users",
+                referencedColumns: ["id"],
+              },
+            ],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("### Constraints");
+      expect(markdown).toContain("| posts_author_fkey | FOREIGN KEY | (author_id) → users(id) |");
+    });
+
+    it("should show nullable status correctly", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "nickname",
+                type: "text",
+                nullable: true,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      // id should be NO (not nullable)
+      expect(markdown).toMatch(/\| \*\*id\*\* \| serial \| - \| NO \|/);
+      // nickname should be YES (nullable)
+      expect(markdown).toMatch(/\| nickname \| text \| - \| YES \|/);
+    });
+
+    it("should show parent/child relations in columns table", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "posts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "author_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "posts",
+            fromColumns: ["author_id"],
+            toTable: "users",
+            toColumns: ["id"],
+            type: "many-to-one",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      // users.id should have posts.author_id as child
+      expect(markdown).toContain("[posts.author_id](#posts)");
+      // posts.author_id should have users.id as parent
+      expect(markdown).toContain("[users.id](#users)");
+    });
+  });
+
+  describe("generateIndex", () => {
+    it("should generate table index", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            comment: "User accounts",
+            columns: [
+              { name: "id", type: "serial", nullable: false, primaryKey: true, unique: false },
+              { name: "name", type: "text", nullable: false, primaryKey: false, unique: false },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "posts",
+            comment: "Blog posts",
+            columns: [
+              { name: "id", type: "serial", nullable: false, primaryKey: true, unique: false },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const index = formatter.generateIndex(schema);
+
+      expect(index).toContain("# Tables");
+      expect(index).toContain("| Name | Columns | Comment |");
+      expect(index).toContain("| [users](#users) | 2 | User accounts |");
+      expect(index).toContain("| [posts](#posts) | 1 | Blog posts |");
+    });
+
+    it("should handle empty tables", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const index = formatter.generateIndex(schema);
+
+      expect(index).toContain("# Tables");
+      expect(index).toContain("No tables defined.");
+    });
+  });
+
+  describe("generateTableDoc", () => {
+    it("should generate complete table documentation", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            comment: "User accounts table",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+                comment: "Primary key",
+              },
+              {
+                name: "email",
+                type: "varchar(255)",
+                nullable: false,
+                primaryKey: false,
+                unique: true,
+                comment: "User email",
+              },
+            ],
+            indexes: [{ name: "users_email_idx", columns: ["email"], unique: true }],
+            constraints: [{ name: "users_pkey", type: "primary_key", columns: ["id"] }],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const tableDoc = formatter.generateTableDoc(schema.tables[0], schema);
+
+      expect(tableDoc).toContain("## users");
+      expect(tableDoc).toContain("User accounts table");
+      expect(tableDoc).toContain("### Columns");
+      expect(tableDoc).toContain("| **id** |");
+      expect(tableDoc).toContain("| email |");
+      expect(tableDoc).toContain("### Indexes");
+      expect(tableDoc).toContain("| users_email_idx |");
+      expect(tableDoc).toContain("### Constraints");
+      expect(tableDoc).toContain("| users_pkey |");
+    });
+  });
+
+  describe("formatter options", () => {
+    it("should exclude comments when includeComments is false", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            comment: "User accounts table",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+                comment: "Primary key",
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter({ includeComments: false });
+      const markdown = formatter.format(schema);
+
+      // Table comment should not appear after heading
+      expect(markdown).not.toMatch(/## users\n\nUser accounts table/);
+      // Column comment should be "-"
+      expect(markdown).toMatch(/\| \*\*id\*\* .* - \|$/m);
+    });
+
+    it("should exclude indexes when includeIndexes is false", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [{ name: "users_idx", columns: ["id"], unique: false }],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter({ includeIndexes: false });
+      const markdown = formatter.format(schema);
+
+      expect(markdown).not.toContain("### Indexes");
+    });
+
+    it("should exclude constraints when includeConstraints is false", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [{ name: "users_pkey", type: "primary_key", columns: ["id"] }],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter({ includeConstraints: false });
+      const markdown = formatter.format(schema);
+
+      expect(markdown).not.toContain("### Constraints");
+    });
+
+    it("should not use relative links when useRelativeLinks is false", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter({ useRelativeLinks: false });
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("| users | 1 |");
+      expect(markdown).not.toContain("[users](#users)");
+    });
+  });
+
+  describe("OutputFormatter interface", () => {
+    it("should implement OutputFormatter interface", () => {
+      const formatter = new MarkdownFormatter();
+      expect(typeof formatter.format).toBe("function");
+    });
+  });
+});

--- a/src/formatter/markdown.ts
+++ b/src/formatter/markdown.ts
@@ -1,0 +1,438 @@
+import type {
+  IntermediateSchema,
+  TableDefinition,
+  ColumnDefinition,
+  IndexDefinition,
+  ConstraintDefinition,
+  RelationDefinition,
+  EnumDefinition,
+} from "../types";
+import type { OutputFormatter, FormatterOptions } from "./types";
+
+/**
+ * Options for MarkdownFormatter
+ */
+export interface MarkdownFormatterOptions extends FormatterOptions {
+  /**
+   * Whether to use relative links for table references
+   * @default true
+   */
+  useRelativeLinks?: boolean;
+}
+
+/**
+ * Default formatter options
+ */
+const DEFAULT_OPTIONS: Required<MarkdownFormatterOptions> = {
+  includeComments: true,
+  includeIndexes: true,
+  includeConstraints: true,
+  useRelativeLinks: true,
+};
+
+/**
+ * MarkdownFormatter converts IntermediateSchema to tbls-style Markdown format
+ *
+ * This formatter generates human-readable Markdown documentation from
+ * the database-agnostic IntermediateSchema representation.
+ *
+ * Output includes:
+ * - Table index (README.md style)
+ * - Individual table documentation with columns, constraints, indexes, and relations
+ */
+export class MarkdownFormatter implements OutputFormatter {
+  private options: Required<MarkdownFormatterOptions>;
+
+  /**
+   * Create a new MarkdownFormatter
+   *
+   * @param options - Formatter options
+   */
+  constructor(options: MarkdownFormatterOptions = {}) {
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  /**
+   * Format the intermediate schema into a single Markdown document
+   *
+   * This generates a complete document containing the index and all table docs.
+   *
+   * @param schema - The intermediate schema to format
+   * @returns Markdown string
+   */
+  format(schema: IntermediateSchema): string {
+    const lines: string[] = [];
+
+    // Generate index section
+    lines.push(this.generateIndex(schema));
+
+    // Generate enum documentation if any
+    if (schema.enums.length > 0) {
+      lines.push("");
+      lines.push("---");
+      lines.push("");
+      lines.push(this.generateEnumsSection(schema.enums));
+    }
+
+    // Generate table documentation
+    for (const table of schema.tables) {
+      lines.push("");
+      lines.push("---");
+      lines.push("");
+      lines.push(this.generateTableDoc(table, schema));
+    }
+
+    return lines.join("\n").trim();
+  }
+
+  /**
+   * Generate the index section (README.md style)
+   *
+   * @param schema - The intermediate schema
+   * @returns Markdown string for the index
+   */
+  generateIndex(schema: IntermediateSchema): string {
+    const lines: string[] = [];
+
+    lines.push("# Tables");
+    lines.push("");
+
+    if (schema.tables.length === 0) {
+      lines.push("No tables defined.");
+      return lines.join("\n");
+    }
+
+    // Table header
+    lines.push("| Name | Columns | Comment |");
+    lines.push("|------|---------|---------|");
+
+    // Table rows
+    for (const table of schema.tables) {
+      const name = this.options.useRelativeLinks
+        ? `[${table.name}](#${this.slugify(table.name)})`
+        : table.name;
+      const columnCount = table.columns.length;
+      const comment =
+        this.options.includeComments && table.comment ? this.escapeMarkdown(table.comment) : "";
+
+      lines.push(`| ${name} | ${columnCount} | ${comment} |`);
+    }
+
+    return lines.join("\n");
+  }
+
+  /**
+   * Generate documentation for a single table
+   *
+   * @param table - The table definition
+   * @param schema - The full schema (for relation lookups)
+   * @returns Markdown string for the table documentation
+   */
+  generateTableDoc(table: TableDefinition, schema: IntermediateSchema): string {
+    const lines: string[] = [];
+
+    // Table heading with anchor
+    lines.push(`## ${table.name}`);
+    lines.push("");
+
+    // Table comment
+    if (this.options.includeComments && table.comment) {
+      lines.push(this.escapeMarkdown(table.comment));
+      lines.push("");
+    }
+
+    // Columns section
+    lines.push(this.generateColumnsTable(table.columns, table.name, schema));
+
+    // Constraints section
+    if (this.options.includeConstraints && table.constraints.length > 0) {
+      lines.push("");
+      lines.push(this.generateConstraintsTable(table.constraints));
+    }
+
+    // Indexes section
+    if (this.options.includeIndexes && table.indexes.length > 0) {
+      lines.push("");
+      lines.push(this.generateIndexesTable(table.indexes));
+    }
+
+    // Relations section
+    const tableRelations = this.getTableRelations(table.name, schema.relations);
+    if (tableRelations.length > 0) {
+      lines.push("");
+      lines.push(this.generateRelationsTable(tableRelations, table.name));
+    }
+
+    return lines.join("\n");
+  }
+
+  /**
+   * Generate the columns table for a table
+   */
+  private generateColumnsTable(
+    columns: ColumnDefinition[],
+    tableName: string,
+    schema: IntermediateSchema,
+  ): string {
+    const lines: string[] = [];
+
+    lines.push("### Columns");
+    lines.push("");
+
+    if (columns.length === 0) {
+      lines.push("No columns defined.");
+      return lines.join("\n");
+    }
+
+    // Build column info with relations
+    const columnInfo = columns.map((col) => {
+      const children = this.getChildRelations(tableName, col.name, schema.relations);
+      const parents = this.getParentRelations(tableName, col.name, schema.relations);
+      return { column: col, children, parents };
+    });
+
+    // Table header
+    lines.push("| Name | Type | Default | Nullable | Children | Parents | Comment |");
+    lines.push("|------|------|---------|----------|----------|---------|---------|");
+
+    // Table rows
+    for (const { column, children, parents } of columnInfo) {
+      const name = column.primaryKey ? `**${column.name}**` : column.name;
+      const type = this.escapeMarkdown(column.type);
+      const defaultVal = column.defaultValue !== undefined ? `\`${column.defaultValue}\`` : "-";
+      const nullable = column.nullable ? "YES" : "NO";
+      const childrenStr = children.length > 0 ? this.formatRelationLinks(children) : "-";
+      const parentsStr = parents.length > 0 ? this.formatRelationLinks(parents) : "-";
+      const comment =
+        this.options.includeComments && column.comment ? this.escapeMarkdown(column.comment) : "-";
+
+      lines.push(
+        `| ${name} | ${type} | ${defaultVal} | ${nullable} | ${childrenStr} | ${parentsStr} | ${comment} |`,
+      );
+    }
+
+    return lines.join("\n");
+  }
+
+  /**
+   * Generate the constraints table
+   */
+  private generateConstraintsTable(constraints: ConstraintDefinition[]): string {
+    const lines: string[] = [];
+
+    lines.push("### Constraints");
+    lines.push("");
+
+    lines.push("| Name | Type | Definition |");
+    lines.push("|------|------|------------|");
+
+    for (const constraint of constraints) {
+      const name = constraint.name || "-";
+      const type = this.formatConstraintType(constraint.type);
+      const definition = this.formatConstraintDefinition(constraint);
+
+      lines.push(`| ${name} | ${type} | ${definition} |`);
+    }
+
+    return lines.join("\n");
+  }
+
+  /**
+   * Generate the indexes table
+   */
+  private generateIndexesTable(indexes: IndexDefinition[]): string {
+    const lines: string[] = [];
+
+    lines.push("### Indexes");
+    lines.push("");
+
+    lines.push("| Name | Columns | Unique | Type |");
+    lines.push("|------|---------|--------|------|");
+
+    for (const index of indexes) {
+      const name = index.name || "-";
+      const columns = index.columns.join(", ");
+      const unique = index.unique ? "YES" : "NO";
+      const type = index.type || "-";
+
+      lines.push(`| ${name} | ${columns} | ${unique} | ${type} |`);
+    }
+
+    return lines.join("\n");
+  }
+
+  /**
+   * Generate the relations table for a specific table
+   */
+  private generateRelationsTable(relations: RelationDefinition[], tableName: string): string {
+    const lines: string[] = [];
+
+    lines.push("### Relations");
+    lines.push("");
+
+    lines.push("| Parent | Child | Type |");
+    lines.push("|--------|-------|------|");
+
+    for (const relation of relations) {
+      const isParent = relation.toTable === tableName;
+      const parent = `${relation.toTable}.${relation.toColumns.join(", ")}`;
+      const child = `${relation.fromTable}.${relation.fromColumns.join(", ")}`;
+      const type = this.formatRelationType(relation.type);
+
+      // Add links if enabled
+      const parentLink = this.options.useRelativeLinks
+        ? `[${parent}](#${this.slugify(relation.toTable)})`
+        : parent;
+      const childLink = this.options.useRelativeLinks
+        ? `[${child}](#${this.slugify(relation.fromTable)})`
+        : child;
+
+      // Highlight the current table
+      const parentDisplay = isParent ? `**${parentLink}**` : parentLink;
+      const childDisplay = !isParent ? `**${childLink}**` : childLink;
+
+      lines.push(`| ${parentDisplay} | ${childDisplay} | ${type} |`);
+    }
+
+    return lines.join("\n");
+  }
+
+  /**
+   * Generate documentation for enums
+   */
+  private generateEnumsSection(enums: EnumDefinition[]): string {
+    const lines: string[] = [];
+
+    lines.push("# Enums");
+    lines.push("");
+
+    for (const enumDef of enums) {
+      lines.push(`## ${enumDef.name}`);
+      lines.push("");
+      lines.push("| Value |");
+      lines.push("|-------|");
+      for (const value of enumDef.values) {
+        lines.push(`| ${value} |`);
+      }
+      lines.push("");
+    }
+
+    return lines.join("\n").trim();
+  }
+
+  /**
+   * Get all relations involving a specific table
+   */
+  private getTableRelations(
+    tableName: string,
+    relations: RelationDefinition[],
+  ): RelationDefinition[] {
+    return relations.filter((r) => r.fromTable === tableName || r.toTable === tableName);
+  }
+
+  /**
+   * Get child relations for a specific column (where this column is referenced)
+   */
+  private getChildRelations(
+    tableName: string,
+    columnName: string,
+    relations: RelationDefinition[],
+  ): Array<{ table: string; column: string }> {
+    return relations
+      .filter((r) => r.toTable === tableName && r.toColumns.includes(columnName))
+      .map((r) => ({
+        table: r.fromTable,
+        column: r.fromColumns.join(", "),
+      }));
+  }
+
+  /**
+   * Get parent relations for a specific column (columns this column references)
+   */
+  private getParentRelations(
+    tableName: string,
+    columnName: string,
+    relations: RelationDefinition[],
+  ): Array<{ table: string; column: string }> {
+    return relations
+      .filter((r) => r.fromTable === tableName && r.fromColumns.includes(columnName))
+      .map((r) => ({
+        table: r.toTable,
+        column: r.toColumns.join(", "),
+      }));
+  }
+
+  /**
+   * Format relation links for display in columns table
+   */
+  private formatRelationLinks(relations: Array<{ table: string; column: string }>): string {
+    return relations
+      .map((r) => {
+        const text = `${r.table}.${r.column}`;
+        return this.options.useRelativeLinks ? `[${text}](#${this.slugify(r.table)})` : text;
+      })
+      .join(", ");
+  }
+
+  /**
+   * Format constraint type for display
+   */
+  private formatConstraintType(type: ConstraintDefinition["type"]): string {
+    const typeMap: Record<ConstraintDefinition["type"], string> = {
+      primary_key: "PRIMARY KEY",
+      foreign_key: "FOREIGN KEY",
+      unique: "UNIQUE",
+      check: "CHECK",
+      not_null: "NOT NULL",
+    };
+    return typeMap[type] || type;
+  }
+
+  /**
+   * Format constraint definition for display
+   */
+  private formatConstraintDefinition(constraint: ConstraintDefinition): string {
+    if (constraint.definition) {
+      return `\`${constraint.definition}\``;
+    }
+
+    const columns = constraint.columns.join(", ");
+
+    if (constraint.type === "foreign_key" && constraint.referencedTable) {
+      const refColumns = constraint.referencedColumns?.join(", ") || "";
+      return `(${columns}) → ${constraint.referencedTable}(${refColumns})`;
+    }
+
+    return `(${columns})`;
+  }
+
+  /**
+   * Format relation type for display
+   */
+  private formatRelationType(type: RelationDefinition["type"]): string {
+    const typeMap: Record<RelationDefinition["type"], string> = {
+      "one-to-one": "One to One",
+      "one-to-many": "One to Many",
+      "many-to-one": "Many to One",
+      "many-to-many": "Many to Many",
+    };
+    return typeMap[type] || type;
+  }
+
+  /**
+   * Create a URL-safe slug from a string
+   */
+  private slugify(str: string): string {
+    return str
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-|-$/g, "");
+  }
+
+  /**
+   * Escape special Markdown characters in a string
+   */
+  private escapeMarkdown(str: string): string {
+    return str.replace(/\|/g, "\\|").replace(/\n/g, " ");
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,5 +42,9 @@ export type {
 } from "./types";
 
 // Output Formatters
-export { DbmlFormatter } from "./formatter/index";
-export type { OutputFormatter, FormatterOptions } from "./formatter/index";
+export { DbmlFormatter, MarkdownFormatter } from "./formatter/index";
+export type {
+  OutputFormatter,
+  FormatterOptions,
+  MarkdownFormatterOptions,
+} from "./formatter/index";


### PR DESCRIPTION
## Summary
- Implement `MarkdownFormatter` class that converts `IntermediateSchema` to tbls-style Markdown documentation
- Add `generateIndex()` method for README.md-style table index generation  
- Add `generateTableDoc()` method for individual table documentation
- Include column tables with parent/child relation links, constraint tables, index tables, and relation tables
- Support enum documentation for PostgreSQL
- Add 24 unit tests covering all functionality

Closes #57

## Test plan
- [x] Run `pnpm test:run` - all 144 tests pass including 24 new MarkdownFormatter tests
- [x] Run `pnpm format && pnpm lint && pnpm typecheck` - all pass