### PR TITLE
feat: implement MermaidErDiagramFormatter for ER diagram generation

### DIFF
--- a/src/formatter/index.ts
+++ b/src/formatter/index.ts
@@ -1,7 +1,9 @@
 // Types
 export type { OutputFormatter, FormatterOptions } from "./types";
+export type { MermaidFormatterOptions } from "./mermaid";
+export type { MarkdownFormatterOptions } from "./markdown";
 
 // Implementations
 export { DbmlFormatter } from "./dbml";
 export { MarkdownFormatter } from "./markdown";
-export type { MarkdownFormatterOptions } from "./markdown";
+export { MermaidErDiagramFormatter } from "./mermaid";

--- a/src/formatter/mermaid.test.ts
+++ b/src/formatter/mermaid.test.ts
@@ -1,0 +1,970 @@
+import { describe, it, expect } from "vitest";
+import { MermaidErDiagramFormatter } from "./mermaid";
+import type { IntermediateSchema } from "../types";
+
+describe("MermaidErDiagramFormatter", () => {
+  describe("format", () => {
+    it("should format a simple table", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "name",
+                type: "text",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+              {
+                name: "email",
+                type: "varchar(255)",
+                nullable: true,
+                primaryKey: false,
+                unique: true,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).toContain("erDiagram");
+      expect(mermaid).toContain("users {");
+      expect(mermaid).toContain("serial id PK");
+      expect(mermaid).toContain("text name");
+      expect(mermaid).toContain("varchar email UK");
+      expect(mermaid).toContain("}");
+    });
+
+    it("should format multiple tables", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "posts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "author_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).toContain("users {");
+      expect(mermaid).toContain("posts {");
+      expect(mermaid).toContain("int author_id");
+    });
+
+    it("should format empty schema", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).toBe("erDiagram");
+    });
+
+    it("should include column comments when enabled", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+                comment: "Primary key",
+              },
+              {
+                name: "name",
+                type: "text",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+                comment: "User display name",
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).toContain('"Primary key"');
+      expect(mermaid).toContain('"User display name"');
+    });
+
+    it("should escape special characters in comments", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+                comment: 'It\'s the "primary" key',
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).toContain('It\'s the \\"primary\\" key');
+    });
+
+    it("should handle names with special characters", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "user-accounts",
+            columns: [
+              {
+                name: "user-id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      // Special characters should be replaced with underscores
+      expect(mermaid).toContain("user_accounts {");
+      expect(mermaid).toContain("user_id");
+    });
+  });
+
+  describe("relations", () => {
+    it("should format one-to-one relations", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "profile_id",
+                type: "integer",
+                nullable: true,
+                primaryKey: false,
+                unique: true,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "profiles",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "users",
+            fromColumns: ["profile_id"],
+            toTable: "profiles",
+            toColumns: ["id"],
+            type: "one-to-one",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).toContain('users ||--|| profiles : "profile_id"');
+    });
+
+    it("should format one-to-many relations", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "posts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "author_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "users",
+            fromColumns: ["id"],
+            toTable: "posts",
+            toColumns: ["author_id"],
+            type: "one-to-many",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).toContain('users ||--o{ posts : "id"');
+    });
+
+    it("should format many-to-one relations", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "posts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "author_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "posts",
+            fromColumns: ["author_id"],
+            toTable: "users",
+            toColumns: ["id"],
+            type: "many-to-one",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).toContain('posts }o--|| users : "author_id"');
+    });
+
+    it("should format many-to-many relations", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "groups",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "user_groups",
+            columns: [
+              {
+                name: "user_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+              {
+                name: "group_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "users",
+            fromColumns: ["id"],
+            toTable: "groups",
+            toColumns: ["id"],
+            type: "many-to-many",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).toContain('users }o--o{ groups : "id"');
+    });
+
+    it("should mark FK columns correctly", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "posts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "author_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "posts",
+            fromColumns: ["author_id"],
+            toTable: "users",
+            toColumns: ["id"],
+            type: "many-to-one",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      // author_id should be marked as FK
+      expect(mermaid).toContain("int author_id FK");
+    });
+
+    it("should handle composite foreign keys", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "orders",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "order_items",
+            columns: [
+              {
+                name: "order_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+              {
+                name: "product_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "order_items",
+            fromColumns: ["order_id", "product_id"],
+            toTable: "orders",
+            toColumns: ["id"],
+            type: "many-to-one",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).toContain("int order_id FK");
+      expect(mermaid).toContain("int product_id FK");
+      expect(mermaid).toContain(': "order_id, product_id"');
+    });
+  });
+
+  describe("formatFocused", () => {
+    it("should return only erDiagram for non-existent table", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.formatFocused(schema, "nonexistent");
+
+      expect(mermaid).toBe("erDiagram");
+    });
+
+    it("should include only the focused table when no relations", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "posts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.formatFocused(schema, "users");
+
+      expect(mermaid).toContain("users {");
+      expect(mermaid).not.toContain("posts {");
+    });
+
+    it("should include related tables through relations", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "posts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "author_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "comments",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "post_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "tags",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "posts",
+            fromColumns: ["author_id"],
+            toTable: "users",
+            toColumns: ["id"],
+            type: "many-to-one",
+          },
+          {
+            fromTable: "comments",
+            fromColumns: ["post_id"],
+            toTable: "posts",
+            toColumns: ["id"],
+            type: "many-to-one",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.formatFocused(schema, "posts");
+
+      // Should include posts (focused), users (related via author_id), comments (related via post_id)
+      expect(mermaid).toContain("posts {");
+      expect(mermaid).toContain("users {");
+      expect(mermaid).toContain("comments {");
+      // Should not include tags (unrelated)
+      expect(mermaid).not.toContain("tags {");
+      // Should include relevant relations
+      expect(mermaid).toContain('posts }o--|| users : "author_id"');
+      expect(mermaid).toContain('comments }o--|| posts : "post_id"');
+    });
+
+    it("should correctly mark FK columns in focused view", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "posts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "author_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "posts",
+            fromColumns: ["author_id"],
+            toTable: "users",
+            toColumns: ["id"],
+            type: "many-to-one",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.formatFocused(schema, "users");
+
+      // author_id should be marked as FK in the focused view
+      expect(mermaid).toContain("int author_id FK");
+    });
+  });
+
+  describe("formatter options", () => {
+    it("should exclude comments when includeComments is false", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+                comment: "Primary key",
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter({ includeComments: false });
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).not.toContain("Primary key");
+      expect(mermaid).not.toContain('"');
+    });
+
+    it("should exclude column types when includeColumnTypes is false", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "name",
+                type: "text",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter({ includeColumnTypes: false });
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).not.toContain("serial");
+      expect(mermaid).not.toContain("text");
+      expect(mermaid).toContain("id PK");
+      expect(mermaid).toContain("name");
+    });
+  });
+
+  describe("type simplification", () => {
+    it("should simplify varchar(255) to varchar", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "email",
+                type: "varchar(255)",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).toContain("varchar email");
+      expect(mermaid).not.toContain("varchar(255)");
+    });
+
+    it("should map integer to int", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "users",
+            columns: [
+              {
+                name: "age",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MermaidErDiagramFormatter();
+      const mermaid = formatter.format(schema);
+
+      expect(mermaid).toContain("int age");
+    });
+  });
+
+  describe("OutputFormatter interface", () => {
+    it("should implement OutputFormatter interface", () => {
+      const formatter = new MermaidErDiagramFormatter();
+      expect(typeof formatter.format).toBe("function");
+    });
+  });
+});

--- a/src/formatter/mermaid.ts
+++ b/src/formatter/mermaid.ts
@@ -1,0 +1,326 @@
+import type {
+  IntermediateSchema,
+  TableDefinition,
+  ColumnDefinition,
+  RelationDefinition,
+} from "../types";
+import type { OutputFormatter, FormatterOptions } from "./types";
+
+/**
+ * Options for MermaidErDiagramFormatter
+ */
+export interface MermaidFormatterOptions extends FormatterOptions {
+  /**
+   * Whether to include column types in the diagram
+   * @default true
+   */
+  includeColumnTypes?: boolean;
+}
+
+/**
+ * Default formatter options
+ */
+const DEFAULT_OPTIONS: Required<MermaidFormatterOptions> = {
+  includeComments: true,
+  includeIndexes: true,
+  includeConstraints: true,
+  includeColumnTypes: true,
+};
+
+/**
+ * MermaidErDiagramFormatter generates Mermaid ER diagram syntax from IntermediateSchema
+ *
+ * This formatter creates Mermaid-compatible ER diagrams that can be rendered
+ * in GitHub, GitLab, or any Mermaid-supporting platform.
+ *
+ * @example
+ * ```typescript
+ * const formatter = new MermaidErDiagramFormatter();
+ * const mermaid = formatter.format(schema);
+ * // Output:
+ * // erDiagram
+ * //     users ||--o{ posts : "author_id"
+ * //     users {
+ * //         int id PK
+ * //         varchar username
+ * //     }
+ * ```
+ *
+ * @see https://mermaid.js.org/syntax/entityRelationshipDiagram.html
+ */
+export class MermaidErDiagramFormatter implements OutputFormatter {
+  private options: Required<MermaidFormatterOptions>;
+
+  /**
+   * Create a new MermaidErDiagramFormatter
+   *
+   * @param options - Formatter options
+   */
+  constructor(options: MermaidFormatterOptions = {}) {
+    this.options = { ...DEFAULT_OPTIONS, ...options };
+  }
+
+  /**
+   * Format the intermediate schema into a Mermaid ER diagram
+   *
+   * @param schema - The intermediate schema to format
+   * @returns Mermaid ER diagram string
+   */
+  format(schema: IntermediateSchema): string {
+    const lines: string[] = ["erDiagram"];
+
+    // Collect foreign key columns for FK markers
+    const fkColumns = this.collectForeignKeyColumns(schema.relations);
+
+    // Generate relations first (at the top of the diagram)
+    for (const relation of schema.relations) {
+      const relationLine = this.formatRelation(relation);
+      if (relationLine) {
+        lines.push(`    ${relationLine}`);
+      }
+    }
+
+    // Add blank line between relations and tables if there are both
+    if (schema.relations.length > 0 && schema.tables.length > 0) {
+      lines.push("");
+    }
+
+    // Generate tables
+    for (const table of schema.tables) {
+      const tableLines = this.formatTable(table, fkColumns);
+      lines.push(...tableLines);
+    }
+
+    return lines.join("\n");
+  }
+
+  /**
+   * Format a focused ER diagram showing only a specific table and its related tables
+   *
+   * @param schema - The intermediate schema
+   * @param tableName - The name of the table to focus on
+   * @returns Mermaid ER diagram string showing only the focused table and its relations
+   */
+  formatFocused(schema: IntermediateSchema, tableName: string): string {
+    // Find the target table
+    const targetTable = schema.tables.find((t) => t.name === tableName);
+    if (!targetTable) {
+      return "erDiagram";
+    }
+
+    // Find related tables through relations
+    const relatedTableNames = new Set<string>([tableName]);
+    const relevantRelations: RelationDefinition[] = [];
+
+    for (const relation of schema.relations) {
+      if (relation.fromTable === tableName || relation.toTable === tableName) {
+        relatedTableNames.add(relation.fromTable);
+        relatedTableNames.add(relation.toTable);
+        relevantRelations.push(relation);
+      }
+    }
+
+    // Filter tables to only include related ones
+    const relevantTables = schema.tables.filter((t) => relatedTableNames.has(t.name));
+
+    // Collect foreign key columns for FK markers
+    const fkColumns = this.collectForeignKeyColumns(relevantRelations);
+
+    const lines: string[] = ["erDiagram"];
+
+    // Generate relations
+    for (const relation of relevantRelations) {
+      const relationLine = this.formatRelation(relation);
+      if (relationLine) {
+        lines.push(`    ${relationLine}`);
+      }
+    }
+
+    // Add blank line between relations and tables if there are both
+    if (relevantRelations.length > 0 && relevantTables.length > 0) {
+      lines.push("");
+    }
+
+    // Generate tables
+    for (const table of relevantTables) {
+      const tableLines = this.formatTable(table, fkColumns);
+      lines.push(...tableLines);
+    }
+
+    return lines.join("\n");
+  }
+
+  /**
+   * Collect foreign key columns from relations for FK marker assignment
+   */
+  private collectForeignKeyColumns(relations: RelationDefinition[]): Map<string, Set<string>> {
+    const fkColumns = new Map<string, Set<string>>();
+
+    for (const relation of relations) {
+      // The "from" side of the relation has the FK column
+      if (!fkColumns.has(relation.fromTable)) {
+        fkColumns.set(relation.fromTable, new Set());
+      }
+      for (const col of relation.fromColumns) {
+        fkColumns.get(relation.fromTable)!.add(col);
+      }
+    }
+
+    return fkColumns;
+  }
+
+  /**
+   * Format a table definition to Mermaid syntax
+   */
+  private formatTable(table: TableDefinition, fkColumns: Map<string, Set<string>>): string[] {
+    const lines: string[] = [];
+    const tableName = this.escapeName(table.name);
+    const tableFkColumns = fkColumns.get(table.name) || new Set();
+
+    lines.push(`    ${tableName} {`);
+
+    for (const column of table.columns) {
+      const columnLine = this.formatColumn(column, tableFkColumns);
+      lines.push(`        ${columnLine}`);
+    }
+
+    lines.push("    }");
+
+    return lines;
+  }
+
+  /**
+   * Format a column definition to Mermaid syntax
+   */
+  private formatColumn(column: ColumnDefinition, fkColumns: Set<string>): string {
+    const parts: string[] = [];
+
+    // Column type (simplified for Mermaid)
+    if (this.options.includeColumnTypes) {
+      parts.push(this.simplifyType(column.type));
+    }
+
+    // Column name
+    parts.push(this.escapeName(column.name));
+
+    // PK/FK markers
+    const markers: string[] = [];
+    if (column.primaryKey) {
+      markers.push("PK");
+    }
+    if (fkColumns.has(column.name)) {
+      markers.push("FK");
+    }
+    if (column.unique && !column.primaryKey) {
+      markers.push("UK");
+    }
+
+    if (markers.length > 0) {
+      parts.push(markers.join(","));
+    }
+
+    // Add comment as Mermaid comment (quoted string after markers)
+    if (this.options.includeComments && column.comment) {
+      parts.push(`"${this.escapeString(column.comment)}"`);
+    }
+
+    return parts.join(" ");
+  }
+
+  /**
+   * Simplify SQL type for Mermaid display
+   *
+   * Mermaid ER diagrams work best with simple type names
+   */
+  private simplifyType(type: string): string {
+    // Remove parentheses content for cleaner display (e.g., varchar(255) -> varchar)
+    const simplified = type.replace(/\([^)]*\)/g, "").toLowerCase();
+
+    // Map common types to shorter versions
+    const typeMap: Record<string, string> = {
+      integer: "int",
+      bigint: "bigint",
+      smallint: "smallint",
+      serial: "serial",
+      bigserial: "bigserial",
+      text: "text",
+      varchar: "varchar",
+      char: "char",
+      boolean: "boolean",
+      timestamp: "timestamp",
+      timestamptz: "timestamptz",
+      date: "date",
+      time: "time",
+      json: "json",
+      jsonb: "jsonb",
+      uuid: "uuid",
+      real: "real",
+      float: "float",
+      double: "double",
+      decimal: "decimal",
+      numeric: "numeric",
+      blob: "blob",
+      bytea: "bytea",
+    };
+
+    return typeMap[simplified] || simplified;
+  }
+
+  /**
+   * Format a relation definition to Mermaid syntax
+   *
+   * Mermaid ER diagram relation syntax:
+   * - ||--|| : one-to-one
+   * - ||--o{ : one-to-many
+   * - }o--|| : many-to-one
+   * - }o--o{ : many-to-many
+   */
+  private formatRelation(relation: RelationDefinition): string {
+    const fromTable = this.escapeName(relation.fromTable);
+    const toTable = this.escapeName(relation.toTable);
+    const symbol = this.getRelationSymbol(relation.type);
+    const label = relation.fromColumns.join(", ");
+
+    return `${fromTable} ${symbol} ${toTable} : "${label}"`;
+  }
+
+  /**
+   * Convert IntermediateRelationType to Mermaid relation symbol
+   *
+   * @see https://mermaid.js.org/syntax/entityRelationshipDiagram.html#relationship-syntax
+   */
+  private getRelationSymbol(type: RelationDefinition["type"]): string {
+    switch (type) {
+      case "one-to-one":
+        return "||--||";
+      case "one-to-many":
+        return "||--o{";
+      case "many-to-one":
+        return "}o--||";
+      case "many-to-many":
+        return "}o--o{";
+    }
+  }
+
+  /**
+   * Escape a name for Mermaid if it contains special characters
+   *
+   * Mermaid entity names should be alphanumeric with underscores
+   */
+  private escapeName(name: string): string {
+    // Mermaid accepts alphanumeric and underscores
+    // For names with special characters, we need to quote them
+    if (/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(name)) {
+      return name;
+    }
+    // Replace special characters with underscores for Mermaid compatibility
+    return name.replace(/[^a-zA-Z0-9_]/g, "_");
+  }
+
+  /**
+   * Escape a string for use in Mermaid quoted strings
+   */
+  private escapeString(str: string): string {
+    return str.replace(/\\/g, "\\\\").replace(/"/g, '\\"').replace(/\n/g, " ");
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,9 +42,10 @@ export type {
 } from "./types";
 
 // Output Formatters
-export { DbmlFormatter, MarkdownFormatter } from "./formatter/index";
+export { DbmlFormatter, MarkdownFormatter, MermaidErDiagramFormatter } from "./formatter/index";
 export type {
   OutputFormatter,
   FormatterOptions,
   MarkdownFormatterOptions,
+  MermaidFormatterOptions,
 } from "./formatter/index";


### PR DESCRIPTION
## Summary
- Implement `MermaidErDiagramFormatter` class in `src/formatter/mermaid.ts`
- Generate Mermaid ER diagram syntax from `IntermediateSchema`
- Support full ER diagram generation and focused table view

## Features
- **Table definition formatting**: Generates Mermaid table syntax with columns
- **Relation type conversion**: Supports 1:1, 1:N, N:1, N:M with proper Mermaid symbols
  - `||--||` for one-to-one
  - `||--o{` for one-to-many
  - `}o--||` for many-to-one
  - `}o--o{` for many-to-many
- **PK/FK/UK markers**: Automatically marks primary keys, foreign keys, and unique keys
- **Type simplification**: Converts `varchar(255)` → `varchar`, `integer` → `int` for cleaner display
- **Full ER diagram**: `format(schema)` generates complete diagram
- **Focused view**: `formatFocused(schema, tableName)` shows only related tables
- **Configurable options**: `includeComments`, `includeColumnTypes`

## Example Output
```mermaid
erDiagram
    posts }o--|| users : "author_id"

    users {
        serial id PK
        varchar username
        varchar email UK
    }

    posts {
        serial id PK
        int author_id FK
        varchar title
        text content
    }
```

## Test plan
- [x] Unit tests added in `src/formatter/mermaid.test.ts` (21 tests)
- [x] All existing tests pass (141 total)
- [x] Integration tests pass (37 tests)
- [x] `pnpm format`, `pnpm lint`, `pnpm typecheck` pass

Closes #58