### PR TITLE
feat: add --format option to CLI for DBML and Markdown output

### DIFF
--- a/src/cli/cli.integration.test.ts
+++ b/src/cli/cli.integration.test.ts
@@ -15,6 +15,10 @@ import {
   hasTableNote,
   countTables,
   countRefs,
+  hasAllMarkdownTables,
+  hasErDiagram,
+  hasTablesIndex,
+  hasColumnsSection,
 } from "../test-utils/dbml-validator.js";
 import { existsSync, mkdirSync, rmSync, readFileSync } from "node:fs";
 import { join } from "node:path";
@@ -455,6 +459,147 @@ describe("CLI Integration Tests", () => {
       expect(countRefs(pgResult.stdout)).toBeGreaterThan(0);
       expect(countRefs(mysqlResult.stdout)).toBeGreaterThan(0);
       expect(countRefs(sqliteResult.stdout)).toBeGreaterThan(0);
+    });
+  });
+
+  // ============================================
+  // Markdown Output Format Tests
+  // ============================================
+  describe("Markdown Format Output", () => {
+    it("should generate Markdown with --format markdown", async () => {
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", { format: "markdown" });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toBe("");
+      expect(hasTablesIndex(result.stdout)).toBe(true);
+      expect(hasAllMarkdownTables(result.stdout, EXPECTED_TABLES)).toBe(true);
+      expect(hasColumnsSection(result.stdout)).toBe(true);
+    });
+
+    it("should include ER diagram by default in Markdown output", async () => {
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", { format: "markdown" });
+
+      expect(result.exitCode).toBe(0);
+      expect(hasErDiagram(result.stdout)).toBe(true);
+    });
+
+    it("should exclude ER diagram with --no-er-diagram", async () => {
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        format: "markdown",
+        noErDiagram: true,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(hasErDiagram(result.stdout)).toBe(false);
+      expect(hasTablesIndex(result.stdout)).toBe(true);
+    });
+
+    it("should output single file Markdown with --single-file", async () => {
+      const outputPath = join(TEST_OUTPUT_DIR, "single-file-output.md");
+
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        format: "markdown",
+        singleFile: true,
+        output: outputPath,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(outputPath)).toBe(true);
+
+      const fileContent = readFileSync(outputPath, "utf-8");
+      expect(hasTablesIndex(fileContent)).toBe(true);
+      expect(hasAllMarkdownTables(fileContent, EXPECTED_TABLES)).toBe(true);
+      expect(hasErDiagram(fileContent)).toBe(true);
+
+      rmSync(outputPath, { force: true });
+    });
+
+    it("should output multiple files Markdown without --single-file", async () => {
+      const outputDir = join(TEST_OUTPUT_DIR, "multi-file-output");
+
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        format: "markdown",
+        output: outputDir,
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      // Check README.md exists
+      expect(existsSync(join(outputDir, "README.md"))).toBe(true);
+
+      // Check individual table files exist
+      for (const tableName of EXPECTED_TABLES) {
+        expect(existsSync(join(outputDir, `${tableName}.md`))).toBe(true);
+      }
+
+      // Verify README.md content
+      const readmeContent = readFileSync(join(outputDir, "README.md"), "utf-8");
+      expect(hasTablesIndex(readmeContent)).toBe(true);
+      expect(hasErDiagram(readmeContent)).toBe(true);
+
+      // Verify individual table file content
+      const usersContent = readFileSync(join(outputDir, "users.md"), "utf-8");
+      expect(usersContent).toContain("# users");
+      expect(usersContent).toContain("### Columns");
+
+      rmSync(outputDir, { recursive: true, force: true });
+    });
+
+    it("should generate Markdown with relations using -r flag", async () => {
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        format: "markdown",
+        relational: true,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stdout).toContain("### Relations");
+      expect(result.stdout).toContain("posts.author_id");
+    });
+
+    it("should work with MySQL dialect in Markdown format", async () => {
+      const result = await runGenerate(MYSQL_SCHEMA_V1, "mysql", { format: "markdown" });
+
+      expect(result.exitCode).toBe(0);
+      expect(hasTablesIndex(result.stdout)).toBe(true);
+      expect(hasAllMarkdownTables(result.stdout, EXPECTED_TABLES)).toBe(true);
+    });
+
+    it("should work with SQLite dialect in Markdown format", async () => {
+      const result = await runGenerate(SQLITE_SCHEMA_V1, "sqlite", { format: "markdown" });
+
+      expect(result.exitCode).toBe(0);
+      expect(hasTablesIndex(result.stdout)).toBe(true);
+      expect(hasAllMarkdownTables(result.stdout, EXPECTED_TABLES)).toBe(true);
+    });
+  });
+
+  // ============================================
+  // Format Option Validation Tests
+  // ============================================
+  describe("Format Option Validation", () => {
+    it("should error for invalid format", async () => {
+      const result = await runCli(["generate", PG_SCHEMA_V0, "-f", "invalid-format"]);
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Invalid format");
+    });
+
+    it("should warn when --single-file used with dbml format", async () => {
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        singleFile: true,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain("--single-file is only applicable with --format markdown");
+    });
+
+    it("should warn when --no-er-diagram used with dbml format", async () => {
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        noErDiagram: true,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(result.stderr).toContain("--no-er-diagram is only applicable with --format markdown");
     });
   });
 });

--- a/src/test-utils/cli-runner.ts
+++ b/src/test-utils/cli-runner.ts
@@ -81,6 +81,9 @@ export async function runGenerate(
   options: {
     output?: string;
     relational?: boolean;
+    format?: "dbml" | "markdown";
+    singleFile?: boolean;
+    noErDiagram?: boolean;
     cwd?: string;
   } = {},
 ): Promise<CliResult> {
@@ -92,6 +95,18 @@ export async function runGenerate(
 
   if (options.relational) {
     args.push("-r");
+  }
+
+  if (options.format) {
+    args.push("-f", options.format);
+  }
+
+  if (options.singleFile) {
+    args.push("--single-file");
+  }
+
+  if (options.noErDiagram) {
+    args.push("--no-er-diagram");
   }
 
   return runCli(args, { cwd: options.cwd });

--- a/src/test-utils/dbml-validator.ts
+++ b/src/test-utils/dbml-validator.ts
@@ -173,3 +173,59 @@ export function countRefs(dbml: string): number {
   const matches = dbml.match(/^Ref:/gm);
   return matches ? matches.length : 0;
 }
+
+// ============================================
+// Markdown validation utilities
+// ============================================
+
+/**
+ * Check if Markdown output contains a table heading
+ *
+ * @param markdown - Markdown output string
+ * @param tableName - Table name to check
+ * @returns true if the table heading exists
+ */
+export function hasMarkdownTable(markdown: string, tableName: string): boolean {
+  return markdown.includes(`## ${tableName}`);
+}
+
+/**
+ * Check if Markdown output contains all expected table headings
+ *
+ * @param markdown - Markdown output string
+ * @param tableNames - Expected table names
+ * @returns true if all table headings are present
+ */
+export function hasAllMarkdownTables(markdown: string, tableNames: string[]): boolean {
+  return tableNames.every((name) => hasMarkdownTable(markdown, name));
+}
+
+/**
+ * Check if Markdown output contains an ER diagram
+ *
+ * @param markdown - Markdown output string
+ * @returns true if ER diagram exists
+ */
+export function hasErDiagram(markdown: string): boolean {
+  return markdown.includes("```mermaid") && markdown.includes("erDiagram");
+}
+
+/**
+ * Check if Markdown output contains the Tables index
+ *
+ * @param markdown - Markdown output string
+ * @returns true if index exists
+ */
+export function hasTablesIndex(markdown: string): boolean {
+  return markdown.includes("# Tables");
+}
+
+/**
+ * Check if Markdown output contains a Columns section for a table
+ *
+ * @param markdown - Markdown output string
+ * @returns true if Columns section exists
+ */
+export function hasColumnsSection(markdown: string): boolean {
+  return markdown.includes("### Columns");
+}


### PR DESCRIPTION
## Summary

Closes #59

Add CLI options to support multiple output formats:
- `--format, -f`: Select output format (`dbml` or `markdown`)
- `--single-file`: Output Markdown as a single file
- `--no-er-diagram`: Exclude ER diagram from Markdown output

## Changes

- Updated CLI to accept `--format` option with `dbml` (default) and `markdown` choices
- Added `--single-file` option for single-file Markdown output
- Added `--no-er-diagram` option to exclude Mermaid ER diagrams from Markdown
- Implemented Formatter selection logic based on format option
- Added validation and warnings for incompatible options
- Updated test utilities (`cli-runner.ts`) to support new options
- Added Markdown validation helpers (`dbml-validator.ts`)
- Added comprehensive integration tests for all new options

## CLI Usage Examples

```bash
# DBML format (existing, default)
drizzle-docs generate ./schema.ts -o schema.dbml

# Markdown format (multiple files)
drizzle-docs generate ./schema.ts --format markdown -o ./docs

# Markdown format (single file)
drizzle-docs generate ./schema.ts --format markdown --single-file -o schema.md

# Markdown without ER diagram
drizzle-docs generate ./schema.ts --format markdown --no-er-diagram -o ./docs
```

## Test plan

- [x] Unit tests pass (`pnpm test:run`)
- [x] Integration tests pass (`pnpm test:integration`)
- [x] Type check passes (`pnpm typecheck`)
- [x] Lint passes (`pnpm lint`)