### PR TITLE
feat: add multi-file output support and --force option

### DIFF
--- a/src/cli/cli.integration.test.ts
+++ b/src/cli/cli.integration.test.ts
@@ -20,7 +20,7 @@ import {
   hasTablesIndex,
   hasColumnsSection,
 } from "../test-utils/dbml-validator.js";
-import { existsSync, mkdirSync, rmSync, readFileSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 
 // Paths to example schemas (v0: relations(), v1: defineRelations())
@@ -600,6 +600,187 @@ describe("CLI Integration Tests", () => {
 
       expect(result.exitCode).toBe(0);
       expect(result.stderr).toContain("--no-er-diagram is only applicable with --format markdown");
+    });
+  });
+
+  // ============================================
+  // Overwrite Protection Tests (--force option)
+  // ============================================
+  describe("Overwrite Protection (--force option)", () => {
+    const forceTestDir = join(TEST_OUTPUT_DIR, "force-test");
+
+    it("should error when output file already exists without --force (DBML)", async () => {
+      const outputPath = join(forceTestDir, "existing.dbml");
+
+      // Create the directory and file
+      mkdirSync(forceTestDir, { recursive: true });
+      writeFileSync(outputPath, "existing content", "utf-8");
+
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        output: outputPath,
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Output file already exists");
+      expect(result.stderr).toContain("--force");
+
+      // Cleanup
+      rmSync(forceTestDir, { recursive: true, force: true });
+    });
+
+    it("should overwrite existing file with --force (DBML)", async () => {
+      const outputPath = join(forceTestDir, "existing.dbml");
+
+      // Create the directory and file
+      mkdirSync(forceTestDir, { recursive: true });
+      writeFileSync(outputPath, "existing content", "utf-8");
+
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        output: outputPath,
+        force: true,
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      // Verify file was overwritten with new content
+      const fileContent = readFileSync(outputPath, "utf-8");
+      expect(fileContent).not.toBe("existing content");
+      expect(fileContent).toContain('Table "users"');
+
+      // Cleanup
+      rmSync(forceTestDir, { recursive: true, force: true });
+    });
+
+    it("should error when output file already exists without --force (Markdown single file)", async () => {
+      const outputPath = join(forceTestDir, "existing.md");
+
+      // Create the directory and file
+      mkdirSync(forceTestDir, { recursive: true });
+      writeFileSync(outputPath, "existing content", "utf-8");
+
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        format: "markdown",
+        singleFile: true,
+        output: outputPath,
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("Output file already exists");
+      expect(result.stderr).toContain("--force");
+
+      // Cleanup
+      rmSync(forceTestDir, { recursive: true, force: true });
+    });
+
+    it("should overwrite existing file with --force (Markdown single file)", async () => {
+      const outputPath = join(forceTestDir, "existing.md");
+
+      // Create the directory and file
+      mkdirSync(forceTestDir, { recursive: true });
+      writeFileSync(outputPath, "existing content", "utf-8");
+
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        format: "markdown",
+        singleFile: true,
+        output: outputPath,
+        force: true,
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      // Verify file was overwritten with new content
+      const fileContent = readFileSync(outputPath, "utf-8");
+      expect(fileContent).not.toBe("existing content");
+      expect(hasTablesIndex(fileContent)).toBe(true);
+
+      // Cleanup
+      rmSync(forceTestDir, { recursive: true, force: true });
+    });
+
+    it("should error when output directory has existing files without --force (Markdown multi-file)", async () => {
+      const outputDir = join(forceTestDir, "multi-file");
+
+      // Create the directory and existing files
+      mkdirSync(outputDir, { recursive: true });
+      writeFileSync(join(outputDir, "README.md"), "existing README", "utf-8");
+
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        format: "markdown",
+        output: outputDir,
+      });
+
+      expect(result.exitCode).toBe(1);
+      expect(result.stderr).toContain("files already exist");
+      expect(result.stderr).toContain("README.md");
+      expect(result.stderr).toContain("--force");
+
+      // Cleanup
+      rmSync(forceTestDir, { recursive: true, force: true });
+    });
+
+    it("should overwrite existing files with --force (Markdown multi-file)", async () => {
+      const outputDir = join(forceTestDir, "multi-file");
+
+      // Create the directory and existing files
+      mkdirSync(outputDir, { recursive: true });
+      writeFileSync(join(outputDir, "README.md"), "existing README", "utf-8");
+      writeFileSync(join(outputDir, "users.md"), "existing users", "utf-8");
+
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        format: "markdown",
+        output: outputDir,
+        force: true,
+      });
+
+      expect(result.exitCode).toBe(0);
+
+      // Verify files were overwritten with new content
+      const readmeContent = readFileSync(join(outputDir, "README.md"), "utf-8");
+      expect(readmeContent).not.toBe("existing README");
+      expect(hasTablesIndex(readmeContent)).toBe(true);
+
+      const usersContent = readFileSync(join(outputDir, "users.md"), "utf-8");
+      expect(usersContent).not.toBe("existing users");
+      expect(usersContent).toContain("# users");
+
+      // Cleanup
+      rmSync(forceTestDir, { recursive: true, force: true });
+    });
+
+    it("should succeed when output directory is empty without --force", async () => {
+      const outputDir = join(forceTestDir, "empty-dir");
+
+      // Create empty directory
+      mkdirSync(outputDir, { recursive: true });
+
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        format: "markdown",
+        output: outputDir,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(join(outputDir, "README.md"))).toBe(true);
+
+      // Cleanup
+      rmSync(forceTestDir, { recursive: true, force: true });
+    });
+
+    it("should succeed when output directory does not exist without --force", async () => {
+      const outputDir = join(forceTestDir, "new-dir");
+
+      // Ensure directory does not exist
+      rmSync(outputDir, { recursive: true, force: true });
+
+      const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+        format: "markdown",
+        output: outputDir,
+      });
+
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(join(outputDir, "README.md"))).toBe(true);
+
+      // Cleanup
+      rmSync(forceTestDir, { recursive: true, force: true });
     });
   });
 });

--- a/src/test-utils/cli-runner.ts
+++ b/src/test-utils/cli-runner.ts
@@ -84,6 +84,7 @@ export async function runGenerate(
     format?: "dbml" | "markdown";
     singleFile?: boolean;
     noErDiagram?: boolean;
+    force?: boolean;
     cwd?: string;
   } = {},
 ): Promise<CliResult> {
@@ -107,6 +108,10 @@ export async function runGenerate(
 
   if (options.noErDiagram) {
     args.push("--no-er-diagram");
+  }
+
+  if (options.force) {
+    args.push("--force");
   }
 
   return runCli(args, { cwd: options.cwd });


### PR DESCRIPTION
## Summary
- Watch モードで複数ファイル Markdown 出力に対応
- `--force` オプションを追加（既存ファイルの上書き保護とスキップ機能）
- DBML、単一ファイル Markdown、複数ファイル Markdown の上書き保護を実装
- `--force` オプションと上書き保護の統合テストを追加

## Test plan
- [x] 既存ファイルがある場合に `--force` なしで実行するとエラーが発生することを確認
- [x] `--force` オプションを指定すると既存ファイルを上書きできることを確認
- [x] 出力先ディレクトリが空または存在しない場合は `--force` なしでも成功することを確認
- [x] Watch モードで複数ファイル出力が正しく動作することを確認
- [x] 全ての統合テストがパス

Closes #60