### PR TITLE
refactor: Phase 2 - DBML生成パスの統一 (#72)

### DIFF
--- a/src/formatter/dbml-builder.ts
+++ b/src/formatter/dbml-builder.ts
@@ -1,0 +1,44 @@
+/**
+ * Simple DBML string builder
+ */
+export class DbmlBuilder {
+  private lines: string[] = [];
+  private indentLevel = 0;
+
+  /**
+   * Increase the indentation level by one
+   * @returns This instance for method chaining
+   */
+  indent(): this {
+    this.indentLevel++;
+    return this;
+  }
+
+  /**
+   * Decrease the indentation level by one (minimum 0)
+   * @returns This instance for method chaining
+   */
+  dedent(): this {
+    this.indentLevel = Math.max(0, this.indentLevel - 1);
+    return this;
+  }
+
+  /**
+   * Add a line with the current indentation level
+   * @param content - The content to add (empty string adds a blank line)
+   * @returns This instance for method chaining
+   */
+  line(content: string = ""): this {
+    const indent = "  ".repeat(this.indentLevel);
+    this.lines.push(content ? `${indent}${content}` : "");
+    return this;
+  }
+
+  /**
+   * Build the final DBML string from all added lines
+   * @returns The complete DBML content as a string
+   */
+  build(): string {
+    return this.lines.join("\n");
+  }
+}

--- a/src/formatter/dbml.test.ts
+++ b/src/formatter/dbml.test.ts
@@ -45,10 +45,10 @@ describe("DbmlFormatter", () => {
       const formatter = new DbmlFormatter();
       const dbml = formatter.format(schema);
 
-      expect(dbml).toContain("Table users {");
-      expect(dbml).toContain("id serial [primary key, not null, increment]");
-      expect(dbml).toContain("name text [not null]");
-      expect(dbml).toContain("email varchar(255) [unique]");
+      expect(dbml).toContain('Table "users" {');
+      expect(dbml).toContain('"id" serial [primary key, not null, increment]');
+      expect(dbml).toContain('"name" text [not null]');
+      expect(dbml).toContain('"email" varchar(255) [unique]');
       expect(dbml).toContain("}");
     });
 
@@ -99,9 +99,9 @@ describe("DbmlFormatter", () => {
       const formatter = new DbmlFormatter();
       const dbml = formatter.format(schema);
 
-      expect(dbml).toContain("Table users {");
-      expect(dbml).toContain("Table posts {");
-      expect(dbml).toContain("author_id integer [not null]");
+      expect(dbml).toContain('Table "users" {');
+      expect(dbml).toContain('Table "posts" {');
+      expect(dbml).toContain('"author_id" integer [not null]');
     });
 
     it("should format columns with default values", () => {
@@ -218,8 +218,8 @@ describe("DbmlFormatter", () => {
       const dbml = formatter.format(schema);
 
       expect(dbml).toContain("indexes {");
-      expect(dbml).toContain("(email) [name: 'email_idx']");
-      expect(dbml).toContain("(email) [unique, name: 'email_unique_idx']");
+      expect(dbml).toContain("(\"email\") [name: 'email_idx']");
+      expect(dbml).toContain("(\"email\") [unique, name: 'email_unique_idx']");
     });
 
     it("should format relations", () => {
@@ -277,7 +277,7 @@ describe("DbmlFormatter", () => {
       const formatter = new DbmlFormatter();
       const dbml = formatter.format(schema);
 
-      expect(dbml).toContain("Ref: posts.author_id > users.id");
+      expect(dbml).toContain('Ref: "posts"."author_id" > "users"."id"');
     });
 
     it("should format one-to-one relations", () => {
@@ -335,7 +335,7 @@ describe("DbmlFormatter", () => {
       const formatter = new DbmlFormatter();
       const dbml = formatter.format(schema);
 
-      expect(dbml).toContain("Ref: users.profile_id - profiles.id");
+      expect(dbml).toContain('Ref: "users"."profile_id" - "profiles"."id"');
     });
 
     it("should format one-to-many relations", () => {
@@ -393,7 +393,7 @@ describe("DbmlFormatter", () => {
       const formatter = new DbmlFormatter();
       const dbml = formatter.format(schema);
 
-      expect(dbml).toContain("Ref: users.id < posts.author_id");
+      expect(dbml).toContain('Ref: "users"."id" < "posts"."author_id"');
     });
 
     it("should format relations with onDelete and onUpdate", () => {
@@ -453,7 +453,9 @@ describe("DbmlFormatter", () => {
       const formatter = new DbmlFormatter();
       const dbml = formatter.format(schema);
 
-      expect(dbml).toContain("Ref: posts.author_id > users.id [delete: cascade, update: set null]");
+      expect(dbml).toContain(
+        'Ref: "posts"."author_id" > "users"."id" [delete: cascade, update: set null]',
+      );
     });
 
     it("should format PostgreSQL enums", () => {
@@ -494,7 +496,7 @@ describe("DbmlFormatter", () => {
       const formatter = new DbmlFormatter();
       const dbml = formatter.format(schema);
 
-      expect(dbml).toContain("Enum user_status {");
+      expect(dbml).toContain('Enum "user_status" {');
       expect(dbml).toContain("active");
       expect(dbml).toContain("inactive");
       expect(dbml).toContain("pending");

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -12,4 +12,5 @@
 export { pgGenerate, PgGenerator } from "./pg";
 export { mysqlGenerate, MySqlGenerator } from "./mysql";
 export { sqliteGenerate, SqliteGenerator } from "./sqlite";
-export { BaseGenerator, DbmlBuilder, writeDbmlFile } from "./common";
+export { BaseGenerator, writeDbmlFile } from "./common";
+export { DbmlBuilder } from "../formatter/dbml-builder";

--- a/src/generator/pg.ts
+++ b/src/generator/pg.ts
@@ -1,6 +1,6 @@
 import { type AnyColumn, getTableColumns } from "drizzle-orm";
 import { PgEnumColumn } from "drizzle-orm/pg-core";
-import { BaseGenerator, DbmlBuilder, writeDbmlFile, type DialectConfig } from "./common";
+import { BaseGenerator, writeDbmlFile, type DialectConfig } from "./common";
 import type { GenerateOptions, EnumDefinition } from "../types";
 
 /**
@@ -19,28 +19,6 @@ export class PgGenerator<
       return sqlType.includes("serial");
     },
   };
-
-  /**
-   * Generate DBML including PostgreSQL-specific constructs like enums
-   */
-  override generate(): string {
-    const dbml = new DbmlBuilder();
-
-    // Generate enums first
-    const enums = this.collectEnums();
-    for (const [name, values] of enums) {
-      this.generateEnum(dbml, name, values);
-      dbml.line();
-    }
-
-    // Then generate tables and refs
-    const baseOutput = super.generate();
-    if (baseOutput) {
-      dbml.line(baseOutput);
-    }
-
-    return dbml.build().trim();
-  }
 
   /**
    * Collect all enum types from the schema
@@ -65,19 +43,6 @@ export class PgGenerator<
     }
 
     return enums;
-  }
-
-  /**
-   * Generate a PostgreSQL enum definition
-   */
-  private generateEnum(dbml: DbmlBuilder, name: string, values: string[]): void {
-    dbml.line(`enum ${this.dialectConfig.escapeName(name)} {`);
-    dbml.indent();
-    for (const value of values) {
-      dbml.line(value);
-    }
-    dbml.dedent();
-    dbml.line("}");
   }
 
   /**


### PR DESCRIPTION
- generate() を toIntermediateSchema() + DbmlFormatter 経由に変更
- 重複メソッドを削除:
  - generateTable(), generateColumn(), generateIndexesBlock()
  - generateRef(), getColumnAttributes(), formatAttributes()
  - parseRelation(), getRelationKey(), escapeDbmlString()
- DbmlBuilder を formatter/dbml-builder.ts に移動
- PgGenerator の generate() オーバーライドを削除
- DbmlFormatter でデータベースタイプに応じた名前エスケープを実装
- DbmlFormatter で制約(PK, unique)をindexesブロックに含めるよう修正