### PR TITLE
refactor: Phase 3 - RelationAdapter の導入 (#73)

### DIFF
--- a/src/adapter/index.ts
+++ b/src/adapter/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Relation adapters for unifying v0 and v1 relation APIs
+ *
+ * This module provides adapters that convert both legacy relations() (v0)
+ * and modern defineRelations() (v1) to a unified format.
+ */
+
+export type { RelationAdapter, UnifiedRelation } from "./types";
+export { V0RelationAdapter } from "./v0-adapter";
+export { V1RelationAdapter } from "./v1-adapter";

--- a/src/adapter/types.ts
+++ b/src/adapter/types.ts
@@ -1,0 +1,40 @@
+/**
+ * Unified relation representation for both v0 (relations()) and v1 (defineRelations())
+ *
+ * This interface provides a common format for relation information extracted
+ * from either API version, enabling consistent processing downstream.
+ */
+export interface UnifiedRelation {
+  /** Source table name (database name, not TypeScript variable) */
+  sourceTable: string;
+  /** Source column names (database names) */
+  sourceColumns: string[];
+  /** Target table name (database name) */
+  targetTable: string;
+  /** Target column names (database names) */
+  targetColumns: string[];
+  /** Type of relation */
+  relationType: "one-to-one" | "one-to-many" | "many-to-one";
+  /** Optional onDelete action (e.g., CASCADE, SET NULL) */
+  onDelete?: string;
+  /** Optional onUpdate action (e.g., CASCADE, SET NULL) */
+  onUpdate?: string;
+}
+
+/**
+ * Adapter interface for extracting relations from different Drizzle ORM APIs
+ *
+ * Implementations handle the specifics of v0 relations() and v1 defineRelations()
+ * APIs, converting them to a unified representation.
+ */
+export interface RelationAdapter {
+  /**
+   * Extract relations from the schema
+   *
+   * Processes the schema to identify and extract all relations, converting
+   * them to the unified format.
+   *
+   * @returns Array of unified relations
+   */
+  extract(): UnifiedRelation[];
+}

--- a/src/adapter/v0-adapter.ts
+++ b/src/adapter/v0-adapter.ts
@@ -1,0 +1,220 @@
+import { type Table, getTableColumns, getTableName, is } from "drizzle-orm";
+import { PgTable } from "drizzle-orm/pg-core";
+import { MySqlTable } from "drizzle-orm/mysql-core";
+import { SQLiteTable } from "drizzle-orm/sqlite-core";
+import type { SchemaRelations } from "../parser/relations";
+import type { RelationAdapter, UnifiedRelation } from "./types";
+
+/**
+ * Adapter for extracting relations from v0 relations() API
+ *
+ * Handles the legacy relations() format by parsing relation definitions
+ * from the TypeScript source using the schema parser.
+ */
+export class V0RelationAdapter implements RelationAdapter {
+  private schema: Record<string, unknown>;
+  private parsedRelations: SchemaRelations | undefined;
+  private tableNameMapping: Map<string, string>;
+  private columnNameMappings: Map<string, Map<string, string>>;
+
+  /**
+   * Create a new V0RelationAdapter
+   *
+   * @param schema - The Drizzle schema object containing tables
+   * @param parsedRelations - Parsed relation information from TypeScript source
+   */
+  constructor(schema: Record<string, unknown>, parsedRelations: SchemaRelations | undefined) {
+    this.schema = schema;
+    this.parsedRelations = parsedRelations;
+    this.tableNameMapping = this.buildTableNameMapping();
+    this.columnNameMappings = new Map();
+  }
+
+  /**
+   * Extract relations from v0 relations() definitions
+   *
+   * Processes parsed relation information to extract foreign key relationships,
+   * determining relation types (one-to-one vs many-to-one) based on bidirectional
+   * analysis.
+   *
+   * @returns Array of unified relations
+   */
+  extract(): UnifiedRelation[] {
+    if (!this.parsedRelations || this.parsedRelations.relations.length === 0) {
+      return [];
+    }
+
+    const relations: UnifiedRelation[] = [];
+    const processedRefs = new Set<string>();
+
+    for (const parsedRelation of this.parsedRelations.relations) {
+      // Only process one() relations with fields and references
+      // many() relations are typically the inverse and don't have field info
+      if (parsedRelation.type !== "one") {
+        continue;
+      }
+
+      if (parsedRelation.fields.length === 0 || parsedRelation.references.length === 0) {
+        continue;
+      }
+
+      // Map variable names to actual table names
+      const fromTableName = this.tableNameMapping.get(parsedRelation.sourceTable);
+      const toTableName = this.tableNameMapping.get(parsedRelation.targetTable);
+
+      if (!fromTableName || !toTableName) {
+        continue;
+      }
+
+      // Get column name mappings (TypeScript property names -> database column names)
+      const fromColumnMapping = this.getColumnNameMapping(parsedRelation.sourceTable);
+      const toColumnMapping = this.getColumnNameMapping(parsedRelation.targetTable);
+
+      // Map TypeScript field names to database column names
+      const fromColumns = parsedRelation.fields.map(
+        (field) => fromColumnMapping.get(field) || field,
+      );
+      const toColumns = parsedRelation.references.map((ref) => toColumnMapping.get(ref) || ref);
+
+      // Create a unique key to avoid duplicate refs (bidirectional)
+      const refKey = `${fromTableName}.${fromColumns.join(",")}-${toTableName}.${toColumns.join(",")}`;
+      const reverseRefKey = `${toTableName}.${toColumns.join(",")}-${fromTableName}.${fromColumns.join(",")}`;
+
+      if (processedRefs.has(refKey) || processedRefs.has(reverseRefKey)) {
+        continue;
+      }
+      processedRefs.add(refKey);
+
+      // Check if this is a one-to-one relationship (bidirectional one())
+      const isOneToOne = this.hasReverseOneRelation(
+        parsedRelation.sourceTable,
+        parsedRelation.targetTable,
+        parsedRelation.fields,
+        parsedRelation.references,
+      );
+
+      // Create UnifiedRelation
+      relations.push({
+        sourceTable: fromTableName,
+        sourceColumns: fromColumns,
+        targetTable: toTableName,
+        targetColumns: toColumns,
+        relationType: isOneToOne ? "one-to-one" : "many-to-one",
+      });
+    }
+
+    return relations;
+  }
+
+  /**
+   * Build a mapping from variable names to table names
+   *
+   * @returns Map of variable names to database table names
+   */
+  private buildTableNameMapping(): Map<string, string> {
+    const mapping = new Map<string, string>();
+    for (const [varName, value] of Object.entries(this.schema)) {
+      if (this.isTable(value)) {
+        const tableName = getTableName(value as Table);
+        mapping.set(varName, tableName);
+      }
+    }
+    return mapping;
+  }
+
+  /**
+   * Check if a value is a Drizzle table
+   *
+   * @param value - The value to check
+   * @returns True if value is a table
+   */
+  private isTable(value: unknown): boolean {
+    return is(value, PgTable) || is(value, MySqlTable) || is(value, SQLiteTable);
+  }
+
+  /**
+   * Get column name mapping for a table
+   *
+   * @param tableVarName - The variable name of the table
+   * @returns Map of property names to database column names
+   */
+  private getColumnNameMapping(tableVarName: string): Map<string, string> {
+    // Check cache first
+    if (this.columnNameMappings.has(tableVarName)) {
+      return this.columnNameMappings.get(tableVarName)!;
+    }
+
+    const mapping = new Map<string, string>();
+    const table = this.schema[tableVarName];
+    if (table && this.isTable(table)) {
+      const columns = getTableColumns(table as Table);
+      for (const [propName, column] of Object.entries(columns)) {
+        mapping.set(propName, column.name);
+      }
+    }
+
+    // Cache the mapping
+    this.columnNameMappings.set(tableVarName, mapping);
+    return mapping;
+  }
+
+  /**
+   * Check if there's a reverse one() relation (B->A when we have A->B)
+   *
+   * Used to detect one-to-one relationships by checking if both tables
+   * have one() relations pointing to each other.
+   *
+   * @param sourceTable - The source table variable name
+   * @param targetTable - The target table variable name
+   * @param sourceFields - The source table's field names
+   * @param targetReferences - The target table's reference column names
+   * @returns True if a reverse one() relation exists
+   */
+  private hasReverseOneRelation(
+    sourceTable: string,
+    targetTable: string,
+    sourceFields: string[],
+    targetReferences: string[],
+  ): boolean {
+    if (!this.parsedRelations) return false;
+
+    // Look for a one() relation from targetTable to sourceTable
+    for (const relation of this.parsedRelations.relations) {
+      if (
+        relation.type === "one" &&
+        relation.sourceTable === targetTable &&
+        relation.targetTable === sourceTable &&
+        relation.fields.length > 0 &&
+        relation.references.length > 0
+      ) {
+        // Check if the fields/references are the reverse of each other
+        // A->B: fields=[A.col], references=[B.col]
+        // B->A: fields=[B.col], references=[A.col]
+        const reverseFields = relation.fields;
+        const reverseReferences = relation.references;
+
+        // The reverse relation's fields should match our references
+        // and the reverse relation's references should match our fields
+        if (
+          this.arraysEqual(reverseFields, targetReferences) &&
+          this.arraysEqual(reverseReferences, sourceFields)
+        ) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Helper to check if two arrays are equal
+   *
+   * @param a - First array
+   * @param b - Second array
+   * @returns True if arrays have same length and same elements in order
+   */
+  private arraysEqual(a: string[], b: string[]): boolean {
+    if (a.length !== b.length) return false;
+    return a.every((val, i) => val === b[i]);
+  }
+}

--- a/src/adapter/v1-adapter.ts
+++ b/src/adapter/v1-adapter.ts
@@ -1,0 +1,141 @@
+import { type Table, getTableName, is, One } from "drizzle-orm";
+import type { AnyRelation, TableRelationalConfig } from "drizzle-orm/relations";
+import type { RelationAdapter, UnifiedRelation } from "./types";
+
+/**
+ * Adapter for extracting relations from v1 defineRelations() API
+ *
+ * Handles the modern v1 defineRelations() format using official Drizzle types
+ * (TableRelationalConfig, AnyRelation, One).
+ */
+export class V1RelationAdapter implements RelationAdapter {
+  private entries: TableRelationalConfig[];
+
+  /**
+   * Create a new V1RelationAdapter
+   *
+   * @param entries - Array of v1 relation entries from defineRelations()
+   */
+  constructor(entries: TableRelationalConfig[]) {
+    this.entries = entries;
+  }
+
+  /**
+   * Extract relations from v1 defineRelations() entries
+   *
+   * Processes One relations to extract foreign key information and generates
+   * relation definitions. Detects one-to-one relationships with bidirectional checks.
+   *
+   * @returns Array of unified relations
+   */
+  extract(): UnifiedRelation[] {
+    const relations: UnifiedRelation[] = [];
+    const processedRefs = new Set<string>();
+
+    for (const entry of this.entries) {
+      const sourceTableName = getTableName(entry.table as Table);
+
+      for (const relation of Object.values(entry.relations)) {
+        // Only process One relations as they define the FK direction
+        // Many relations are the inverse and don't add new information
+        if (!is(relation, One)) {
+          continue;
+        }
+
+        // Skip reversed relations (they are auto-generated inverse relations)
+        if ((relation as AnyRelation).isReversed) {
+          continue;
+        }
+
+        // Get source and target column names (using official Relation properties)
+        const rel = relation as AnyRelation;
+        const sourceColumns = rel.sourceColumns.map((col) => col.name);
+        const targetColumns = rel.targetColumns.map((col) => col.name);
+
+        if (sourceColumns.length === 0 || targetColumns.length === 0) {
+          continue;
+        }
+
+        const targetTableName = getTableName(rel.targetTable as Table);
+
+        // Create a unique key to avoid duplicate refs
+        const refKey = `${sourceTableName}.${sourceColumns.join(",")}->${targetTableName}.${targetColumns.join(",")}`;
+        const reverseRefKey = `${targetTableName}.${targetColumns.join(",")}->${sourceTableName}.${sourceColumns.join(",")}`;
+
+        if (processedRefs.has(refKey) || processedRefs.has(reverseRefKey)) {
+          continue;
+        }
+        processedRefs.add(refKey);
+
+        // Check if there's a reverse one() relation (indicating one-to-one)
+        const isOneToOne = this.hasReverseOneRelation(
+          targetTableName,
+          sourceTableName,
+          targetColumns,
+          sourceColumns,
+        );
+
+        relations.push({
+          sourceTable: sourceTableName,
+          sourceColumns,
+          targetTable: targetTableName,
+          targetColumns,
+          relationType: isOneToOne ? "one-to-one" : "many-to-one",
+        });
+      }
+    }
+
+    return relations;
+  }
+
+  /**
+   * Check if there's a reverse One relation in v1 entries
+   *
+   * Detects one-to-one relationships by checking if the target table
+   * has a matching One relation pointing back to the source table.
+   *
+   * @param fromTableName - The table to search for reverse relation
+   * @param toTableName - The expected target table of the reverse relation
+   * @param fromColumns - The expected source columns of the reverse relation
+   * @param toColumns - The expected target columns of the reverse relation
+   * @returns True if a matching reverse One relation exists
+   */
+  private hasReverseOneRelation(
+    fromTableName: string,
+    toTableName: string,
+    fromColumns: string[],
+    toColumns: string[],
+  ): boolean {
+    const fromEntry = this.entries.find((e) => getTableName(e.table as Table) === fromTableName);
+    if (!fromEntry) {
+      return false;
+    }
+
+    for (const relation of Object.values(fromEntry.relations)) {
+      if (!is(relation, One)) {
+        continue;
+      }
+
+      const rel = relation as AnyRelation;
+      const relTargetName = getTableName(rel.targetTable as Table);
+      if (relTargetName !== toTableName) {
+        continue;
+      }
+
+      const relSourceCols = rel.sourceColumns.map((col) => col.name);
+      const relTargetCols = rel.targetColumns.map((col) => col.name);
+
+      // Check if columns match in reverse
+      if (
+        relSourceCols.length === fromColumns.length &&
+        relTargetCols.length === toColumns.length &&
+        relSourceCols.every((col, i) => col === fromColumns[i]) &&
+        relTargetCols.every((col, i) => col === toColumns[i])
+      ) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
v0 (relations()) と v1 (defineRelations()) のリレーション処理を
統一インターフェースで抽象化し、コードの重複を削減。

## 変更内容

### 新規ファイル
- `src/adapter/types.ts`: UnifiedRelation, RelationAdapter インターフェース定義
- `src/adapter/v0-adapter.ts`: V0RelationAdapter 実装
- `src/adapter/v1-adapter.ts`: V1RelationAdapter 実装
- `src/adapter/index.ts`: エクスポート

### 変更ファイル
- `src/generator/common.ts`:
  - アダプター経由でリレーション処理 (createRelationAdapter, unifiedRelationToDefinition)
  - 重複メソッド削除:
    - generateRelationalRefsFromV0()
    - generateRelationalRefsFromV1()
    - hasReverseOneRelation()
    - hasV1ReverseOneRelation()
  - 未使用 import 削除 (One, AnyRelation)

## テスト結果
- ✓ pnpm test:run (165 tests)
- ✓ pnpm test:integration (56 tests)

Closes #73