### PR TITLE
feat: preserve newlines in JSDoc comments for better formatting

### DIFF
--- a/src/formatter/markdown.ts
+++ b/src/formatter/markdown.ts
@@ -144,9 +144,9 @@ export class MarkdownFormatter implements OutputFormatter {
     lines.push(`## ${table.name}`);
     lines.push("");
 
-    // Table comment
+    // Table comment (preserve newlines as <br> for better readability)
     if (this.options.includeComments && table.comment) {
-      lines.push(this.escapeMarkdown(table.comment));
+      lines.push(this.escapeMarkdownWithBreaks(table.comment));
       lines.push("");
     }
 
@@ -451,8 +451,17 @@ export class MarkdownFormatter implements OutputFormatter {
 
   /**
    * Escape special Markdown characters in a string
+   * Converts newlines to spaces for use in table cells
    */
   private escapeMarkdown(str: string): string {
     return str.replace(/\|/g, "\\|").replace(/\n/g, " ");
+  }
+
+  /**
+   * Escape special Markdown characters and convert newlines to <br> tags
+   * Used for better readability in text sections (not in tables)
+   */
+  private escapeMarkdownWithBreaks(str: string): string {
+    return str.replace(/\|/g, "\\|").replace(/\n/g, "  \n");
   }
 }

--- a/src/parser/comments.test.ts
+++ b/src/parser/comments.test.ts
@@ -99,7 +99,7 @@ export const users = pgTable("users", {
       const comments = extractComments(filePath);
 
       expect(comments.tables.users.comment).toBe(
-        "This table stores user account information. It includes basic profile data.",
+        "This table stores user account information.\nIt includes basic profile data.",
       );
     });
 
@@ -121,7 +121,7 @@ export const users = pgTable("users", {
       const comments = extractComments(filePath);
 
       expect(comments.tables.users.columns.id?.comment).toBe(
-        "Unique identifier for the user. Auto-incremented.",
+        "Unique identifier for the user.\nAuto-incremented.",
       );
     });
 

--- a/src/parser/comments.ts
+++ b/src/parser/comments.ts
@@ -238,6 +238,8 @@ function getJsDocComment(node: ts.Node, sourceFile: ts.SourceFile): string | und
 
 /**
  * Parse JSDoc comment text to extract the description
+ *
+ * Preserves newlines in the output for proper formatting in DBML and Markdown.
  */
 function parseJsDocComment(commentText: string): string {
   // Remove /** and */
@@ -259,6 +261,16 @@ function parseJsDocComment(commentText: string): string {
     contentLines.push(line);
   }
 
-  // Join and trim
-  return contentLines.join(" ").trim();
+  // Remove trailing empty lines
+  while (contentLines.length > 0 && contentLines[contentLines.length - 1] === "") {
+    contentLines.pop();
+  }
+
+  // Remove leading empty lines
+  while (contentLines.length > 0 && contentLines[0] === "") {
+    contentLines.shift();
+  }
+
+  // Join with newlines to preserve formatting
+  return contentLines.join("\n").trim();
 }


### PR DESCRIPTION
- Modified parseJsDocComment to preserve newlines instead of collapsing them to spaces
- DBML output now preserves multiline comments with proper \n escaping
- Markdown output now converts newlines to <br> (two spaces + newline) for table descriptions
- Markdown tables still convert newlines to spaces for proper formatting
- Updated comments.test.ts to reflect the new behavior

This allows for better documentation formatting when schemas contain detailed multiline JSDoc comments with sections and lists.