### PR TITLE
Fix markdown link generation for underscored table names

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle-docs-generator",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "A CLI tool that generates DBML files from Drizzle ORM schema definitions.",
   "keywords": [
     "cli",

--- a/src/formatter/markdown.test.ts
+++ b/src/formatter/markdown.test.ts
@@ -980,4 +980,146 @@ describe("MarkdownFormatter", () => {
       expect(typeof formatter.format).toBe("function");
     });
   });
+
+  describe("table names with underscores", () => {
+    it("should preserve underscores in anchor links for table names", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "user_accounts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      // Table header should preserve underscore
+      expect(markdown).toContain("## user_accounts");
+      // Index table link should preserve underscore in anchor
+      expect(markdown).toContain("| [user_accounts](#user_accounts) | 1 |");
+    });
+
+    it("should preserve underscores in anchor links for multiple underscore tables", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "post_tags",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "user_profiles",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      // Both table headers should preserve underscores
+      expect(markdown).toContain("## post_tags");
+      expect(markdown).toContain("## user_profiles");
+      // Index table links should preserve underscores in anchors
+      expect(markdown).toContain("| [post_tags](#post_tags) |");
+      expect(markdown).toContain("| [user_profiles](#user_profiles) |");
+    });
+
+    it("should preserve underscores in relation links for underscore table names", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "user_accounts",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+          {
+            name: "post_tags",
+            columns: [
+              {
+                name: "id",
+                type: "serial",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "user_id",
+                type: "integer",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "post_tags",
+            fromColumns: ["user_id"],
+            toTable: "user_accounts",
+            toColumns: ["id"],
+            type: "many-to-one",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      // Relation links should preserve underscores in anchors
+      expect(markdown).toContain("[user_accounts](#user_accounts)");
+      expect(markdown).toContain("[post_tags](#post_tags)");
+    });
+  });
 });

--- a/src/formatter/markdown.ts
+++ b/src/formatter/markdown.ts
@@ -427,17 +427,6 @@ export class MarkdownFormatter implements OutputFormatter {
     };
     return typeMap[type] || type;
   }
-
-  /**
-   * Create a URL-safe slug from a string
-   */
-  private slugify(str: string): string {
-    return str
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, "-")
-      .replace(/^-|-$/g, "");
-  }
-
   /**
    * Create a table link based on the configured link format
    */
@@ -446,7 +435,7 @@ export class MarkdownFormatter implements OutputFormatter {
     if (this.options.linkFormat === "file") {
       return `[${text}](./${tableName}.md)`;
     }
-    return `[${text}](#${this.slugify(tableName)})`;
+    return `[${text}](#${tableName})`;
   }
 
   /**


### PR DESCRIPTION
Preserve underscores in anchor links for table names (e.g., user_accounts -> #user_accounts). Previously, the slugify() function was converting underscores to hyphens (user_accounts -> #user-accounts), which didn't match the actual markdown headers and caused links to break. Now table names are used as-is in anchor links, matching GitHub Flavored Markdown specifications.