### PR TITLE
chore: rename workflow from auto-release to release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Auto Release
+name: Release
 
 on:
   push:


### PR DESCRIPTION
## Summary

Simplify workflow naming by renaming `auto-release.yml` to `release.yml`.

## Changes

- Rename `.github/workflows/auto-release.yml` to `.github/workflows/release.yml`
- Update workflow name from "Auto Release" to "Release"

This is a cosmetic change to simplify the workflow name while maintaining the same functionality.