### PR TITLE
fix(parser): extract JSDoc comments for tables defined via v1 casing helpers

### DIFF
--- a/src/generator/pg.test.ts
+++ b/src/generator/pg.test.ts
@@ -12,6 +12,7 @@ import {
   foreignKey,
   unique,
   index,
+  snakeCase,
 } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm/_relations";
 import type { SchemaComments } from "../parser/comments";
@@ -819,6 +820,34 @@ export const users = pgTable("users", {
     expect(dbml).toContain("Note: 'Users table with account info'");
     expect(dbml).toContain("note: 'Auto-generated ID'");
     expect(dbml).toContain("note: 'Full name'");
+  });
+
+  it("should extract comments for tables defined via snakeCase.table (v1 casing helper)", () => {
+    const schemaCode = `
+import { integer, snakeCase } from "drizzle-orm/pg-core";
+
+/** brands table */
+export const bikeBrandsTable = snakeCase.table("bike_brands", {
+  /** unique code of the brand */
+  code: integer().notNull().unique(),
+  /** owner of the brand */
+  ownerId: integer(),
+});
+`;
+    const filePath = join(TEST_DIR, "schema-snake-case-comments.ts");
+    writeFileSync(filePath, schemaCode);
+
+    const bikeBrandsTable = snakeCase.table("bike_brands", {
+      code: integer().notNull().unique(),
+      ownerId: integer(),
+    });
+
+    const dbml = pgGenerate({ schema: { bikeBrandsTable }, source: filePath });
+
+    expect(dbml).toContain('Table "bike_brands" {');
+    expect(dbml).toContain("Note: 'brands table'");
+    expect(dbml).toContain("\"code\" integer [not null, unique, note: 'unique code of the brand']");
+    expect(dbml).toContain("\"owner_id\" integer [note: 'owner of the brand']");
   });
 
   it("should escape special characters in comments", () => {

--- a/src/parser/comments.test.ts
+++ b/src/parser/comments.test.ts
@@ -685,6 +685,106 @@ export const auth = snakeCase.schema("auth");
     });
   });
 
+  describe("Drizzle binding verification", () => {
+    it("should resolve casing helpers through a namespace import", () => {
+      const schemaCode = `
+import * as pg from "drizzle-orm/pg-core";
+import { integer } from "drizzle-orm/pg-core";
+
+/** Users table */
+export const users = pg.snakeCase.table("users", {
+  /** user's id */
+  userId: integer(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-namespace-import.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.users.comment).toBe("Users table");
+      expect(comments.tables.users.columns.user_id?.comment).toBe("user's id");
+    });
+
+    it("should scope import aliases per file", () => {
+      const schemaDir = join(TEST_DIR, "v1-alias-per-file-dir");
+      mkdirSync(schemaDir, { recursive: true });
+      // The same alias `c` is bound to different casing helpers in each file
+      writeFileSync(
+        join(schemaDir, "a.ts"),
+        `
+import { integer, snakeCase as c } from "drizzle-orm/pg-core";
+
+export const posts = c.table("posts", {
+  /** author's id */
+  authorId: integer(),
+});
+`,
+      );
+      writeFileSync(
+        join(schemaDir, "b.ts"),
+        `
+import { int, camelCase as c } from "drizzle-orm/mysql-core";
+
+export const comments = c.table("comments", {
+  /** post's id */
+  post_id: int(),
+});
+`,
+      );
+
+      const comments = extractComments(schemaDir);
+
+      expect(comments.tables.posts.columns.author_id?.comment).toBe("author's id");
+      expect(comments.tables.comments.columns.postId?.comment).toBe("post's id");
+    });
+
+    it("should ignore casing helpers imported from non-Drizzle modules", () => {
+      const schemaCode = `
+import { integer } from "drizzle-orm/pg-core";
+import { snakeCase } from "change-case";
+
+/** Not a Drizzle table */
+export const users = snakeCase.table("users", {
+  /** user's id */
+  userId: integer(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-non-drizzle-import.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.users).toBeUndefined();
+    });
+
+    it("should ignore .table() calls whose receiver is not a Drizzle binding", () => {
+      const schemaCode = `
+import { integer } from "drizzle-orm/pg-core";
+import { builder } from "./builder";
+
+/** Not a Drizzle table */
+export const users = builder.table("users", {
+  /** user's id */
+  userId: integer(),
+});
+
+/** Not a Drizzle table either */
+export const posts = builder.snakeCase.table("posts", {
+  /** post's id */
+  postId: integer(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-unknown-receiver.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.users).toBeUndefined();
+      expect(comments.tables.posts).toBeUndefined();
+    });
+  });
+
   describe("Columns without explicit names", () => {
     it("should use the property key as-is for pgTable columns without a name", () => {
       const schemaCode = `

--- a/src/parser/comments.test.ts
+++ b/src/parser/comments.test.ts
@@ -450,3 +450,302 @@ export const users = pgTable("users", {
     });
   });
 });
+
+describe("extractComments with Drizzle v1 table helpers", () => {
+  beforeAll(() => {
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  afterAll(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  describe("Casing helpers (snakeCase.table / camelCase.table)", () => {
+    it("should extract comments from snakeCase.table and convert keys to snake_case", () => {
+      const schemaCode = `
+import { integer, snakeCase } from "drizzle-orm/pg-core";
+
+/** brands table */
+export const bikeBrandsTable = snakeCase.table("bike_brands", {
+  /** unique code of the brand */
+  code: integer().notNull().unique(),
+  /** owner of the brand */
+  ownerId: integer(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-snake-case-table.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.bike_brands).toBeDefined();
+      expect(comments.tables.bike_brands.comment).toBe("brands table");
+      expect(comments.tables.bike_brands.columns.code?.comment).toBe("unique code of the brand");
+      expect(comments.tables.bike_brands.columns.owner_id?.comment).toBe("owner of the brand");
+      expect(comments.tables.bike_brands.columns.ownerId).toBeUndefined();
+    });
+
+    it("should extract comments from camelCase.table and convert keys to camelCase", () => {
+      const schemaCode = `
+import { integer, camelCase } from "drizzle-orm/pg-core";
+
+/** brands table */
+export const brands = camelCase.table("brands", {
+  /** owner of the brand */
+  owner_id: integer(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-camel-case-table.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.brands.comment).toBe("brands table");
+      expect(comments.tables.brands.columns.ownerId?.comment).toBe("owner of the brand");
+    });
+
+    it("should prefer an explicit column name over the casing-converted key", () => {
+      const schemaCode = `
+import { integer, snakeCase } from "drizzle-orm/pg-core";
+
+export const brands = snakeCase.table("brands", {
+  /** explicit name wins */
+  ownerId: integer("owner"),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-snake-case-explicit-name.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.brands.columns.owner?.comment).toBe("explicit name wins");
+      expect(comments.tables.brands.columns.owner_id).toBeUndefined();
+    });
+
+    it("should support import aliases of casing helpers", () => {
+      const schemaCode = `
+import { integer, snakeCase as sc } from "drizzle-orm/pg-core";
+
+/** aliased table */
+export const brands = sc.table("brands", {
+  /** owner of the brand */
+  ownerId: integer(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-snake-case-alias.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.brands.comment).toBe("aliased table");
+      expect(comments.tables.brands.columns.owner_id?.comment).toBe("owner of the brand");
+    });
+
+    it("should handle withRLS on casing helpers", () => {
+      const schemaCode = `
+import { integer, snakeCase } from "drizzle-orm/pg-core";
+
+/** RLS table */
+export const brands = snakeCase.table.withRLS("brands", {
+  /** owner of the brand */
+  ownerId: integer(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-snake-case-rls.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.brands.comment).toBe("RLS table");
+      expect(comments.tables.brands.columns.owner_id?.comment).toBe("owner of the brand");
+    });
+
+    it("should handle MySQL and SQLite casing helpers", () => {
+      const schemaCode = `
+import { int, snakeCase as mysqlSnakeCase } from "drizzle-orm/mysql-core";
+import { integer, camelCase as sqliteCamelCase } from "drizzle-orm/sqlite-core";
+
+/** MySQL brands */
+export const mysqlBrands = mysqlSnakeCase.table("mysql_brands", {
+  /** MySQL owner */
+  ownerId: int(),
+});
+
+/** SQLite brands */
+export const sqliteBrands = sqliteCamelCase.table("sqlite_brands", {
+  /** SQLite owner */
+  owner_id: integer(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-casing-other-dialects.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.mysql_brands.comment).toBe("MySQL brands");
+      expect(comments.tables.mysql_brands.columns.owner_id?.comment).toBe("MySQL owner");
+      expect(comments.tables.sqlite_brands.comment).toBe("SQLite brands");
+      expect(comments.tables.sqlite_brands.columns.ownerId?.comment).toBe("SQLite owner");
+    });
+  });
+
+  describe("Schema helpers (pgSchema / snakeCase.schema)", () => {
+    it("should extract comments from pgSchema(...).table without casing conversion", () => {
+      const schemaCode = `
+import { integer, pgSchema } from "drizzle-orm/pg-core";
+
+export const auth = pgSchema("auth");
+
+/** Auth users */
+export const users = auth.table("users", {
+  /** user's id */
+  userId: integer(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-pg-schema.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.users.comment).toBe("Auth users");
+      expect(comments.tables.users.columns.userId?.comment).toBe("user's id");
+    });
+
+    it("should apply casing from a schema variable created with snakeCase.schema", () => {
+      const schemaCode = `
+import { integer, snakeCase } from "drizzle-orm/pg-core";
+
+export const auth = snakeCase.schema("auth");
+
+/** Auth users */
+export const users = auth.table("users", {
+  /** user's id */
+  userId: integer(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-snake-case-schema-variable.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.users.comment).toBe("Auth users");
+      expect(comments.tables.users.columns.user_id?.comment).toBe("user's id");
+    });
+
+    it("should apply casing from an inline camelCase.schema(...).table call", () => {
+      const schemaCode = `
+import { integer, camelCase } from "drizzle-orm/pg-core";
+
+/** Auth users */
+export const users = camelCase.schema("auth").table("users", {
+  /** user's id */
+  user_id: integer(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-camel-case-schema-inline.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.users.comment).toBe("Auth users");
+      expect(comments.tables.users.columns.userId?.comment).toBe("user's id");
+    });
+
+    it("should resolve a schema variable declared in another file of a directory", () => {
+      const schemaDir = join(TEST_DIR, "v1-schema-dir");
+      mkdirSync(schemaDir, { recursive: true });
+      // The table file sorts before the schema file on purpose:
+      // the schema variable must be resolvable regardless of the file order
+      writeFileSync(
+        join(schemaDir, "a-tables.ts"),
+        `
+import { integer } from "drizzle-orm/pg-core";
+import { auth } from "./z-schema";
+
+/** Auth users */
+export const users = auth.table("users", {
+  /** user's id */
+  userId: integer(),
+});
+`,
+      );
+      writeFileSync(
+        join(schemaDir, "z-schema.ts"),
+        `
+import { snakeCase } from "drizzle-orm/pg-core";
+
+export const auth = snakeCase.schema("auth");
+`,
+      );
+
+      const comments = extractComments(schemaDir);
+
+      expect(comments.tables.users.comment).toBe("Auth users");
+      expect(comments.tables.users.columns.user_id?.comment).toBe("user's id");
+    });
+  });
+
+  describe("Columns without explicit names", () => {
+    it("should use the property key as-is for pgTable columns without a name", () => {
+      const schemaCode = `
+import { pgTable, serial, varchar, timestamp } from "drizzle-orm/pg-core";
+
+export const users = pgTable("users", {
+  /** Primary key */
+  id: serial().primaryKey(),
+  /** Display name */
+  displayName: varchar({ length: 100 }).notNull(),
+  /** Creation time */
+  createdAt: timestamp({ mode: "date" }).defaultNow(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-keyless-columns.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.users.columns.id?.comment).toBe("Primary key");
+      expect(comments.tables.users.columns.displayName?.comment).toBe("Display name");
+      expect(comments.tables.users.columns.createdAt?.comment).toBe("Creation time");
+    });
+
+    it("should handle withRLS on pgTable without casing conversion", () => {
+      const schemaCode = `
+import { pgTable, integer } from "drizzle-orm/pg-core";
+
+/** RLS table */
+export const users = pgTable.withRLS("users", {
+  /** user's id */
+  userId: integer(),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-pg-table-rls.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.users.comment).toBe("RLS table");
+      expect(comments.tables.users.columns.userId?.comment).toBe("user's id");
+    });
+
+    it("should skip columns whose name is not statically known", () => {
+      const schemaCode = `
+import { pgTable, integer } from "drizzle-orm/pg-core";
+
+const dynamicName = "computed";
+
+export const users = pgTable("users", {
+  /** Unknown name */
+  id: integer(dynamicName),
+});
+`;
+      const filePath = join(TEST_DIR, "v1-dynamic-column-name.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.users).toBeDefined();
+      expect(Object.keys(comments.tables.users.columns)).toHaveLength(0);
+    });
+  });
+});

--- a/src/parser/comments.ts
+++ b/src/parser/comments.ts
@@ -26,18 +26,13 @@ export interface SchemaComments {
 }
 
 /**
- * Context shared across all files while parsing
+ * Column casing associated with an identifier, shared across all parsed files.
+ *
+ * Holds import aliases of the Drizzle v1 casing helpers
+ * (e.g., `import { snakeCase as sc }`) and schema variables created from them
+ * (e.g., `const auth = snakeCase.schema("auth")`).
  */
-interface ParseContext {
-  /**
-   * Column casing associated with an identifier.
-   *
-   * Holds import aliases of the Drizzle v1 casing helpers
-   * (e.g., `import { snakeCase as sc }`) and schema variables created from them
-   * (e.g., `const auth = snakeCase.schema("auth")`).
-   */
-  casingByIdentifier: Map<string, Casing>;
-}
+type CasingByIdentifier = Map<string, Casing>;
 
 /**
  * Get all TypeScript files from a path (file or directory)
@@ -87,7 +82,7 @@ function getTypeScriptFiles(sourcePath: string): string[] {
 export function extractComments(sourcePath: string): SchemaComments {
   const comments: SchemaComments = { tables: {} };
   const files = getTypeScriptFiles(sourcePath);
-  const context: ParseContext = { casingByIdentifier: new Map() };
+  const casingByIdentifier: CasingByIdentifier = new Map();
 
   const sourceFiles = files.map((filePath) => {
     const sourceCode = readFileSync(filePath, "utf-8");
@@ -97,55 +92,61 @@ export function extractComments(sourcePath: string): SchemaComments {
   // First pass: collect casing helper aliases and schema variables across all files,
   // so that tables can resolve their casing regardless of file/declaration order
   for (const sourceFile of sourceFiles) {
-    collectCasingIdentifiers(sourceFile, context);
+    collectCasingIdentifiers(sourceFile, casingByIdentifier);
   }
 
   // Second pass: extract table and column comments
   for (const sourceFile of sourceFiles) {
-    visitNode(sourceFile, sourceFile, comments, context);
+    visitNode(sourceFile, sourceFile, comments, casingByIdentifier);
   }
 
   return comments;
 }
 
 /**
- * Recursively visit AST nodes to record identifiers that carry a column casing
+ * Record top-level identifiers that carry a column casing
  *
  * - `import { snakeCase as sc } from "drizzle-orm/pg-core"` -> sc: snake_case
  * - `const auth = snakeCase.schema("auth")` -> auth: snake_case
+ *
+ * Only module-level statements are inspected: imports are always top-level and
+ * schema variables are declared there in practice.
  */
-function collectCasingIdentifiers(node: ts.Node, context: ParseContext): void {
-  if (ts.isImportDeclaration(node)) {
-    const namedBindings = node.importClause?.namedBindings;
-    if (namedBindings && ts.isNamedImports(namedBindings)) {
-      for (const element of namedBindings.elements) {
-        const importedName = element.propertyName?.text ?? element.name.text;
-        const casing = getCasingFromHelperName(importedName);
-        if (casing) {
-          context.casingByIdentifier.set(element.name.text, casing);
+function collectCasingIdentifiers(
+  sourceFile: ts.SourceFile,
+  casingByIdentifier: CasingByIdentifier,
+): void {
+  for (const statement of sourceFile.statements) {
+    if (ts.isImportDeclaration(statement)) {
+      const namedBindings = statement.importClause?.namedBindings;
+      if (namedBindings && ts.isNamedImports(namedBindings)) {
+        for (const element of namedBindings.elements) {
+          const importedName = element.propertyName?.text ?? element.name.text;
+          const casing = getCasingFromHelperName(importedName);
+          if (casing) {
+            casingByIdentifier.set(element.name.text, casing);
+          }
+        }
+      }
+    }
+
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        const initializer = declaration.initializer;
+        if (
+          ts.isIdentifier(declaration.name) &&
+          initializer &&
+          ts.isCallExpression(initializer) &&
+          getCallExpressionName(initializer) === "schema"
+        ) {
+          const casing = resolveCasing(initializer, casingByIdentifier);
+          if (casing) {
+            casingByIdentifier.set(declaration.name.text, casing);
+          }
         }
       }
     }
   }
-
-  if (ts.isVariableStatement(node)) {
-    for (const declaration of node.declarationList.declarations) {
-      const initializer = declaration.initializer;
-      if (
-        ts.isIdentifier(declaration.name) &&
-        initializer &&
-        ts.isCallExpression(initializer) &&
-        getCallExpressionName(initializer) === "schema"
-      ) {
-        const casing = resolveCasing(initializer, context);
-        if (casing) {
-          context.casingByIdentifier.set(declaration.name.text, casing);
-        }
-      }
-    }
-  }
-
-  ts.forEachChild(node, (child) => collectCasingIdentifiers(child, context));
 }
 
 /**
@@ -155,7 +156,7 @@ function visitNode(
   node: ts.Node,
   sourceFile: ts.SourceFile,
   comments: SchemaComments,
-  context: ParseContext,
+  casingByIdentifier: CasingByIdentifier,
 ): void {
   // Look for variable declarations that define tables
   if (ts.isVariableStatement(node)) {
@@ -171,7 +172,7 @@ function visitNode(
           declaration.initializer,
           sourceFile,
           jsDocComment,
-          context,
+          casingByIdentifier,
         );
         if (tableInfo) {
           comments.tables[tableInfo.tableName] = tableInfo.tableComment;
@@ -180,7 +181,7 @@ function visitNode(
     }
   }
 
-  ts.forEachChild(node, (child) => visitNode(child, sourceFile, comments, context));
+  ts.forEachChild(node, (child) => visitNode(child, sourceFile, comments, casingByIdentifier));
 }
 
 /**
@@ -191,7 +192,7 @@ function parseTableDefinition(
   callExpr: ts.CallExpression,
   sourceFile: ts.SourceFile,
   tableJsDoc: string | undefined,
-  context: ParseContext,
+  casingByIdentifier: CasingByIdentifier,
 ): { tableName: string; tableComment: TableComment } | undefined {
   const funcName = getCallExpressionName(callExpr);
 
@@ -208,7 +209,7 @@ function parseTableDefinition(
   const tableName = tableNameArg.text;
 
   // Casing applied to property keys of columns without an explicit name
-  const casingFn = getCasingFn(resolveCasing(callExpr.expression, context));
+  const casingFn = getCasingFn(resolveCasing(callExpr.expression, casingByIdentifier));
 
   // Get column definitions from second argument
   const columnsArg = callExpr.arguments[1];
@@ -281,15 +282,20 @@ function getCasingFromHelperName(name: string): Casing | undefined {
  * - `authSchema.table` (where `authSchema = snakeCase.schema("auth")`) -> snake_case
  * - `pgTable`, `pgSchema("auth").table` -> undefined (no casing conversion)
  */
-function resolveCasing(expr: ts.Expression, context: ParseContext): Casing | undefined {
+function resolveCasing(
+  expr: ts.Expression,
+  casingByIdentifier: CasingByIdentifier,
+): Casing | undefined {
   if (ts.isIdentifier(expr)) {
-    return getCasingFromHelperName(expr.text) ?? context.casingByIdentifier.get(expr.text);
+    return getCasingFromHelperName(expr.text) ?? casingByIdentifier.get(expr.text);
   }
   if (ts.isPropertyAccessExpression(expr)) {
-    return getCasingFromHelperName(expr.name.text) ?? resolveCasing(expr.expression, context);
+    return (
+      getCasingFromHelperName(expr.name.text) ?? resolveCasing(expr.expression, casingByIdentifier)
+    );
   }
   if (ts.isCallExpression(expr)) {
-    return resolveCasing(expr.expression, context);
+    return resolveCasing(expr.expression, casingByIdentifier);
   }
   return undefined;
 }

--- a/src/parser/comments.ts
+++ b/src/parser/comments.ts
@@ -26,13 +26,66 @@ export interface SchemaComments {
 }
 
 /**
- * Column casing associated with an identifier, shared across all parsed files.
+ * Column casing carried by a Drizzle helper binding
  *
- * Holds import aliases of the Drizzle v1 casing helpers
- * (e.g., `import { snakeCase as sc }`) and schema variables created from them
- * (e.g., `const auth = snakeCase.schema("auth")`).
+ * - "snake_case" / "camelCase": Drizzle v1 casing helpers (`snakeCase`, `camelCase`)
+ * - "none": other Drizzle helpers that keep property keys as-is (`pgTable`, `pgSchema`, ...)
  */
-type CasingByIdentifier = Map<string, Casing>;
+type BindingCasing = Casing | "none";
+
+/**
+ * Drizzle helpers that can appear in the receiver chain of a table definition,
+ * mapped to the casing they apply to column property keys
+ */
+const DRIZZLE_HELPER_CASINGS = new Map<string, BindingCasing>([
+  ["snakeCase", "snake_case"],
+  ["camelCase", "camelCase"],
+  ["pgTable", "none"],
+  ["mysqlTable", "none"],
+  ["sqliteTable", "none"],
+  ["pgSchema", "none"],
+  ["mysqlSchema", "none"],
+  ["mysqlDatabase", "none"],
+]);
+
+/**
+ * Classic table helpers, accepted by name (`pgTable("users", ...)`)
+ */
+const CLASSIC_TABLE_HELPERS = ["pgTable", "mysqlTable", "sqliteTable"];
+
+/**
+ * Schema helpers whose result carries the casing of its receiver
+ * (`snakeCase.schema("auth")`, `pgSchema("auth")`)
+ */
+const SCHEMA_HELPERS = ["schema", "pgSchema", "mysqlSchema", "mysqlDatabase"];
+
+/**
+ * Drizzle bindings imported by a single source file
+ *
+ * - `helpers`: local names of helpers imported from `drizzle-orm*` modules
+ *   (`import { snakeCase as sc } from "drizzle-orm/pg-core"` -> sc: snake_case)
+ * - `namespaces`: namespace imports of `drizzle-orm*` modules
+ *   (`import * as pg from "drizzle-orm/pg-core"` -> pg)
+ *
+ * Kept per file so that the same alias can be bound to different helpers in different files.
+ */
+interface FileBindings {
+  helpers: Map<string, BindingCasing>;
+  namespaces: Set<string>;
+}
+
+/**
+ * Bindings visible from the file being parsed
+ *
+ * - `file`: import bindings of the file
+ * - `schemaVariables`: schema variables declared in any parsed file
+ *   (`export const auth = snakeCase.schema("auth")`), so that a table file can
+ *   import them from another file
+ */
+interface CasingScope {
+  file: FileBindings;
+  schemaVariables: Map<string, BindingCasing>;
+}
 
 /**
  * Get all TypeScript files from a path (file or directory)
@@ -82,67 +135,93 @@ function getTypeScriptFiles(sourcePath: string): string[] {
 export function extractComments(sourcePath: string): SchemaComments {
   const comments: SchemaComments = { tables: {} };
   const files = getTypeScriptFiles(sourcePath);
-  const casingByIdentifier: CasingByIdentifier = new Map();
+  const schemaVariables = new Map<string, BindingCasing>();
 
-  const sourceFiles = files.map((filePath) => {
+  const scopes = files.map((filePath): [ts.SourceFile, CasingScope] => {
     const sourceCode = readFileSync(filePath, "utf-8");
-    return ts.createSourceFile(filePath, sourceCode, ts.ScriptTarget.Latest, true);
+    const sourceFile = ts.createSourceFile(filePath, sourceCode, ts.ScriptTarget.Latest, true);
+    return [sourceFile, { file: collectImportBindings(sourceFile), schemaVariables }];
   });
 
-  // First pass: collect casing helper aliases and schema variables across all files,
+  // First pass: collect schema variables across all files,
   // so that tables can resolve their casing regardless of file/declaration order
-  for (const sourceFile of sourceFiles) {
-    collectCasingIdentifiers(sourceFile, casingByIdentifier);
+  for (const [sourceFile, scope] of scopes) {
+    collectSchemaVariables(sourceFile, scope);
   }
 
   // Second pass: extract table and column comments
-  for (const sourceFile of sourceFiles) {
-    visitNode(sourceFile, sourceFile, comments, casingByIdentifier);
+  for (const [sourceFile, scope] of scopes) {
+    visitNode(sourceFile, sourceFile, comments, scope);
   }
 
   return comments;
 }
 
 /**
- * Record top-level identifiers that carry a column casing
- *
- * - `import { snakeCase as sc } from "drizzle-orm/pg-core"` -> sc: snake_case
- * - `const auth = snakeCase.schema("auth")` -> auth: snake_case
- *
- * Only module-level statements are inspected: imports are always top-level and
- * schema variables are declared there in practice.
+ * Check if a module specifier refers to Drizzle ORM
+ * (`drizzle-orm`, `drizzle-orm/pg-core`, ...)
  */
-function collectCasingIdentifiers(
-  sourceFile: ts.SourceFile,
-  casingByIdentifier: CasingByIdentifier,
-): void {
+function isDrizzleModule(moduleSpecifier: ts.Expression): boolean {
+  return ts.isStringLiteral(moduleSpecifier) && moduleSpecifier.text.startsWith("drizzle-orm");
+}
+
+/**
+ * Collect Drizzle helper bindings imported by a source file
+ *
+ * Only imports from `drizzle-orm*` modules are recorded, so that a `snakeCase`
+ * imported from an unrelated library is not mistaken for the Drizzle helper.
+ */
+function collectImportBindings(sourceFile: ts.SourceFile): FileBindings {
+  const bindings: FileBindings = { helpers: new Map(), namespaces: new Set() };
+
   for (const statement of sourceFile.statements) {
-    if (ts.isImportDeclaration(statement)) {
-      const namedBindings = statement.importClause?.namedBindings;
-      if (namedBindings && ts.isNamedImports(namedBindings)) {
-        for (const element of namedBindings.elements) {
-          const importedName = element.propertyName?.text ?? element.name.text;
-          const casing = getCasingFromHelperName(importedName);
-          if (casing) {
-            casingByIdentifier.set(element.name.text, casing);
-          }
+    if (!ts.isImportDeclaration(statement) || !isDrizzleModule(statement.moduleSpecifier)) {
+      continue;
+    }
+    const namedBindings = statement.importClause?.namedBindings;
+    if (!namedBindings) {
+      continue;
+    }
+    if (ts.isNamespaceImport(namedBindings)) {
+      bindings.namespaces.add(namedBindings.name.text);
+    } else {
+      for (const element of namedBindings.elements) {
+        const importedName = element.propertyName?.text ?? element.name.text;
+        const casing = DRIZZLE_HELPER_CASINGS.get(importedName);
+        if (casing) {
+          bindings.helpers.set(element.name.text, casing);
         }
       }
     }
+  }
 
-    if (ts.isVariableStatement(statement)) {
-      for (const declaration of statement.declarationList.declarations) {
-        const initializer = declaration.initializer;
-        if (
-          ts.isIdentifier(declaration.name) &&
-          initializer &&
-          ts.isCallExpression(initializer) &&
-          getCallExpressionName(initializer) === "schema"
-        ) {
-          const casing = resolveCasing(initializer, casingByIdentifier);
-          if (casing) {
-            casingByIdentifier.set(declaration.name.text, casing);
-          }
+  return bindings;
+}
+
+/**
+ * Record top-level schema variables created from a Drizzle binding
+ *
+ * - `const auth = snakeCase.schema("auth")` -> auth: snake_case
+ * - `const auth = pgSchema("auth")` -> auth: none
+ *
+ * Only module-level statements are inspected: schema variables are declared there in practice.
+ */
+function collectSchemaVariables(sourceFile: ts.SourceFile, scope: CasingScope): void {
+  for (const statement of sourceFile.statements) {
+    if (!ts.isVariableStatement(statement)) {
+      continue;
+    }
+    for (const declaration of statement.declarationList.declarations) {
+      const initializer = declaration.initializer;
+      if (
+        ts.isIdentifier(declaration.name) &&
+        initializer &&
+        ts.isCallExpression(initializer) &&
+        SCHEMA_HELPERS.includes(getCallExpressionName(initializer) ?? "")
+      ) {
+        const casing = resolveCasing(initializer, scope);
+        if (casing) {
+          scope.schemaVariables.set(declaration.name.text, casing);
         }
       }
     }
@@ -156,7 +235,7 @@ function visitNode(
   node: ts.Node,
   sourceFile: ts.SourceFile,
   comments: SchemaComments,
-  casingByIdentifier: CasingByIdentifier,
+  scope: CasingScope,
 ): void {
   // Look for variable declarations that define tables
   if (ts.isVariableStatement(node)) {
@@ -172,7 +251,7 @@ function visitNode(
           declaration.initializer,
           sourceFile,
           jsDocComment,
-          casingByIdentifier,
+          scope,
         );
         if (tableInfo) {
           comments.tables[tableInfo.tableName] = tableInfo.tableComment;
@@ -181,7 +260,7 @@ function visitNode(
     }
   }
 
-  ts.forEachChild(node, (child) => visitNode(child, sourceFile, comments, casingByIdentifier));
+  ts.forEachChild(node, (child) => visitNode(child, sourceFile, comments, scope));
 }
 
 /**
@@ -192,12 +271,10 @@ function parseTableDefinition(
   callExpr: ts.CallExpression,
   sourceFile: ts.SourceFile,
   tableJsDoc: string | undefined,
-  casingByIdentifier: CasingByIdentifier,
+  scope: CasingScope,
 ): { tableName: string; tableComment: TableComment } | undefined {
-  const funcName = getCallExpressionName(callExpr);
-
   // Check if this is a table definition function
-  if (!isTableDefinitionFunction(funcName)) {
+  if (!isTableDefinition(callExpr, scope)) {
     return undefined;
   }
 
@@ -209,7 +286,8 @@ function parseTableDefinition(
   const tableName = tableNameArg.text;
 
   // Casing applied to property keys of columns without an explicit name
-  const casingFn = getCasingFn(resolveCasing(callExpr.expression, casingByIdentifier));
+  const casing = resolveCasing(callExpr.expression, scope);
+  const casingFn = getCasingFn(casing === "none" ? undefined : casing);
 
   // Get column definitions from second argument
   const columnsArg = callExpr.arguments[1];
@@ -251,25 +329,24 @@ function getCallExpressionName(callExpr: ts.CallExpression): string | undefined 
 }
 
 /**
- * Check if a function name is a table definition function
+ * Check if a call expression is a table definition
  *
- * - pgTable / mysqlTable / sqliteTable: classic table helpers
- * - table: Drizzle v1 casing helpers (`snakeCase.table(...)`) and
- *   schema helpers (`pgSchema("auth").table(...)`)
- * - withRLS: PostgreSQL RLS variant (`pgTable.withRLS(...)`)
+ * - pgTable / mysqlTable / sqliteTable: classic table helpers, accepted by name
+ * - table / withRLS: accepted only when the receiver resolves to a Drizzle binding
+ *   (`snakeCase.table(...)`, `pgSchema("auth").table(...)`, `pgTable.withRLS(...)`),
+ *   so that unrelated `.table()` calls are not mistaken for table definitions
  */
-function isTableDefinitionFunction(funcName: string | undefined): boolean {
+function isTableDefinition(callExpr: ts.CallExpression, scope: CasingScope): boolean {
+  const funcName = getCallExpressionName(callExpr);
   if (!funcName) return false;
-  return ["pgTable", "mysqlTable", "sqliteTable", "table", "withRLS"].includes(funcName);
-}
-
-/**
- * Map a Drizzle v1 casing helper name to its casing
- */
-function getCasingFromHelperName(name: string): Casing | undefined {
-  if (name === "snakeCase") return "snake_case";
-  if (name === "camelCase") return "camelCase";
-  return undefined;
+  if (CLASSIC_TABLE_HELPERS.includes(funcName)) return true;
+  if (funcName === "table" || funcName === "withRLS") {
+    return (
+      ts.isPropertyAccessExpression(callExpr.expression) &&
+      resolveCasing(callExpr.expression.expression, scope) !== undefined
+    );
+  }
+  return false;
 }
 
 /**
@@ -280,22 +357,24 @@ function getCasingFromHelperName(name: string): Casing | undefined {
  * - `snakeCase.table.withRLS` -> snake_case
  * - `camelCase.schema("auth").table` -> camelCase
  * - `authSchema.table` (where `authSchema = snakeCase.schema("auth")`) -> snake_case
- * - `pgTable`, `pgSchema("auth").table` -> undefined (no casing conversion)
+ * - `pg.snakeCase.table` (where `pg` is a namespace import) -> snake_case
+ * - `pgTable.withRLS`, `pgSchema("auth").table` -> none (no casing conversion)
+ * - anything not bound to a Drizzle helper -> undefined
  */
-function resolveCasing(
-  expr: ts.Expression,
-  casingByIdentifier: CasingByIdentifier,
-): Casing | undefined {
+function resolveCasing(expr: ts.Expression, scope: CasingScope): BindingCasing | undefined {
   if (ts.isIdentifier(expr)) {
-    return getCasingFromHelperName(expr.text) ?? casingByIdentifier.get(expr.text);
+    return scope.file.helpers.get(expr.text) ?? scope.schemaVariables.get(expr.text);
   }
   if (ts.isPropertyAccessExpression(expr)) {
-    return (
-      getCasingFromHelperName(expr.name.text) ?? resolveCasing(expr.expression, casingByIdentifier)
-    );
+    // Helper accessed through a namespace import (`pg.snakeCase`)
+    if (ts.isIdentifier(expr.expression) && scope.file.namespaces.has(expr.expression.text)) {
+      return DRIZZLE_HELPER_CASINGS.get(expr.name.text);
+    }
+    // `.table`, `.withRLS`, `.schema` keep the casing of their receiver
+    return resolveCasing(expr.expression, scope);
   }
   if (ts.isCallExpression(expr)) {
-    return resolveCasing(expr.expression, casingByIdentifier);
+    return resolveCasing(expr.expression, scope);
   }
   return undefined;
 }

--- a/src/parser/comments.ts
+++ b/src/parser/comments.ts
@@ -1,4 +1,5 @@
 import * as ts from "typescript";
+import { getCasingFn, type Casing } from "drizzle-orm/casing";
 import { readFileSync, statSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 
@@ -22,6 +23,20 @@ export interface TableComment {
  */
 export interface SchemaComments {
   tables: Record<string, TableComment>;
+}
+
+/**
+ * Context shared across all files while parsing
+ */
+interface ParseContext {
+  /**
+   * Column casing associated with an identifier.
+   *
+   * Holds import aliases of the Drizzle v1 casing helpers
+   * (e.g., `import { snakeCase as sc }`) and schema variables created from them
+   * (e.g., `const auth = snakeCase.schema("auth")`).
+   */
+  casingByIdentifier: Map<string, Casing>;
 }
 
 /**
@@ -57,8 +72,14 @@ function getTypeScriptFiles(sourcePath: string): string[] {
  * Extract JSDoc comments from a Drizzle schema source file or directory
  *
  * Parses TypeScript source files and extracts:
- * - JSDoc comments on table definitions (e.g., pgTable, mysqlTable, sqliteTable)
+ * - JSDoc comments on table definitions
+ *   (e.g., pgTable, mysqlTable, sqliteTable, snakeCase.table, mySchema.table)
  * - JSDoc comments on column definitions within tables
+ *
+ * Column comments are keyed by the database column name. When a column has no
+ * explicit name (Drizzle v1 style, e.g., `authorId: integer()`), the property key is
+ * converted using the casing of the table helper (`snakeCase.table` -> `author_id`),
+ * matching what Drizzle does at runtime.
  *
  * @param sourcePath - Path to the TypeScript schema file or directory
  * @returns Extracted comments organized by table and column
@@ -66,22 +87,76 @@ function getTypeScriptFiles(sourcePath: string): string[] {
 export function extractComments(sourcePath: string): SchemaComments {
   const comments: SchemaComments = { tables: {} };
   const files = getTypeScriptFiles(sourcePath);
+  const context: ParseContext = { casingByIdentifier: new Map() };
 
-  for (const filePath of files) {
+  const sourceFiles = files.map((filePath) => {
     const sourceCode = readFileSync(filePath, "utf-8");
-    const sourceFile = ts.createSourceFile(filePath, sourceCode, ts.ScriptTarget.Latest, true);
+    return ts.createSourceFile(filePath, sourceCode, ts.ScriptTarget.Latest, true);
+  });
 
-    // Visit all nodes in the source file
-    visitNode(sourceFile, sourceFile, comments);
+  // First pass: collect casing helper aliases and schema variables across all files,
+  // so that tables can resolve their casing regardless of file/declaration order
+  for (const sourceFile of sourceFiles) {
+    collectCasingIdentifiers(sourceFile, context);
+  }
+
+  // Second pass: extract table and column comments
+  for (const sourceFile of sourceFiles) {
+    visitNode(sourceFile, sourceFile, comments, context);
   }
 
   return comments;
 }
 
 /**
+ * Recursively visit AST nodes to record identifiers that carry a column casing
+ *
+ * - `import { snakeCase as sc } from "drizzle-orm/pg-core"` -> sc: snake_case
+ * - `const auth = snakeCase.schema("auth")` -> auth: snake_case
+ */
+function collectCasingIdentifiers(node: ts.Node, context: ParseContext): void {
+  if (ts.isImportDeclaration(node)) {
+    const namedBindings = node.importClause?.namedBindings;
+    if (namedBindings && ts.isNamedImports(namedBindings)) {
+      for (const element of namedBindings.elements) {
+        const importedName = element.propertyName?.text ?? element.name.text;
+        const casing = getCasingFromHelperName(importedName);
+        if (casing) {
+          context.casingByIdentifier.set(element.name.text, casing);
+        }
+      }
+    }
+  }
+
+  if (ts.isVariableStatement(node)) {
+    for (const declaration of node.declarationList.declarations) {
+      const initializer = declaration.initializer;
+      if (
+        ts.isIdentifier(declaration.name) &&
+        initializer &&
+        ts.isCallExpression(initializer) &&
+        getCallExpressionName(initializer) === "schema"
+      ) {
+        const casing = resolveCasing(initializer, context);
+        if (casing) {
+          context.casingByIdentifier.set(declaration.name.text, casing);
+        }
+      }
+    }
+  }
+
+  ts.forEachChild(node, (child) => collectCasingIdentifiers(child, context));
+}
+
+/**
  * Recursively visit AST nodes to find table and column definitions
  */
-function visitNode(node: ts.Node, sourceFile: ts.SourceFile, comments: SchemaComments): void {
+function visitNode(
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+  comments: SchemaComments,
+  context: ParseContext,
+): void {
   // Look for variable declarations that define tables
   if (ts.isVariableStatement(node)) {
     const jsDocComment = getJsDocComment(node, sourceFile);
@@ -93,10 +168,10 @@ function visitNode(node: ts.Node, sourceFile: ts.SourceFile, comments: SchemaCom
         ts.isCallExpression(declaration.initializer)
       ) {
         const tableInfo = parseTableDefinition(
-          declaration.name.text,
           declaration.initializer,
           sourceFile,
           jsDocComment,
+          context,
         );
         if (tableInfo) {
           comments.tables[tableInfo.tableName] = tableInfo.tableComment;
@@ -105,17 +180,18 @@ function visitNode(node: ts.Node, sourceFile: ts.SourceFile, comments: SchemaCom
     }
   }
 
-  ts.forEachChild(node, (child) => visitNode(child, sourceFile, comments));
+  ts.forEachChild(node, (child) => visitNode(child, sourceFile, comments, context));
 }
 
 /**
- * Parse a table definition call expression (e.g., pgTable("users", { ... }))
+ * Parse a table definition call expression
+ * (e.g., pgTable("users", { ... }), snakeCase.table("users", { ... }))
  */
 function parseTableDefinition(
-  _variableName: string,
   callExpr: ts.CallExpression,
   sourceFile: ts.SourceFile,
   tableJsDoc: string | undefined,
+  context: ParseContext,
 ): { tableName: string; tableComment: TableComment } | undefined {
   const funcName = getCallExpressionName(callExpr);
 
@@ -131,6 +207,9 @@ function parseTableDefinition(
   }
   const tableName = tableNameArg.text;
 
+  // Casing applied to property keys of columns without an explicit name
+  const casingFn = getCasingFn(resolveCasing(callExpr.expression, context));
+
   // Get column definitions from second argument
   const columnsArg = callExpr.arguments[1];
   const columnComments: Record<string, ColumnComment> = {};
@@ -138,7 +217,7 @@ function parseTableDefinition(
   if (columnsArg && ts.isObjectLiteralExpression(columnsArg)) {
     for (const property of columnsArg.properties) {
       if (ts.isPropertyAssignment(property) && ts.isIdentifier(property.name)) {
-        const columnName = extractColumnName(property.initializer);
+        const columnName = extractColumnName(property.initializer, property.name.text, casingFn);
         const columnJsDoc = getJsDocComment(property, sourceFile);
 
         if (columnName && columnJsDoc) {
@@ -172,17 +251,65 @@ function getCallExpressionName(callExpr: ts.CallExpression): string | undefined 
 
 /**
  * Check if a function name is a table definition function
+ *
+ * - pgTable / mysqlTable / sqliteTable: classic table helpers
+ * - table: Drizzle v1 casing helpers (`snakeCase.table(...)`) and
+ *   schema helpers (`pgSchema("auth").table(...)`)
+ * - withRLS: PostgreSQL RLS variant (`pgTable.withRLS(...)`)
  */
 function isTableDefinitionFunction(funcName: string | undefined): boolean {
   if (!funcName) return false;
-  return ["pgTable", "mysqlTable", "sqliteTable"].includes(funcName);
+  return ["pgTable", "mysqlTable", "sqliteTable", "table", "withRLS"].includes(funcName);
+}
+
+/**
+ * Map a Drizzle v1 casing helper name to its casing
+ */
+function getCasingFromHelperName(name: string): Casing | undefined {
+  if (name === "snakeCase") return "snake_case";
+  if (name === "camelCase") return "camelCase";
+  return undefined;
+}
+
+/**
+ * Resolve the column casing from the callee of a table definition
+ *
+ * Walks the receiver chain of expressions such as:
+ * - `snakeCase.table` -> snake_case
+ * - `snakeCase.table.withRLS` -> snake_case
+ * - `camelCase.schema("auth").table` -> camelCase
+ * - `authSchema.table` (where `authSchema = snakeCase.schema("auth")`) -> snake_case
+ * - `pgTable`, `pgSchema("auth").table` -> undefined (no casing conversion)
+ */
+function resolveCasing(expr: ts.Expression, context: ParseContext): Casing | undefined {
+  if (ts.isIdentifier(expr)) {
+    return getCasingFromHelperName(expr.text) ?? context.casingByIdentifier.get(expr.text);
+  }
+  if (ts.isPropertyAccessExpression(expr)) {
+    return getCasingFromHelperName(expr.name.text) ?? resolveCasing(expr.expression, context);
+  }
+  if (ts.isCallExpression(expr)) {
+    return resolveCasing(expr.expression, context);
+  }
+  return undefined;
 }
 
 /**
  * Extract the actual column name from a column definition
- * e.g., serial("id") -> "id", text("name") -> "name"
+ *
+ * - Explicit name: serial("id") -> "id", text("name") -> "name"
+ * - No name (Drizzle v1 style): integer(), varchar({ length: 255 })
+ *   -> property key converted with the table's casing (e.g., authorId -> author_id)
+ *
+ * @param expr - The column definition expression (including chained calls)
+ * @param propertyKey - The property key of the column in the table definition
+ * @param casingFn - Casing function to apply to the property key
  */
-function extractColumnName(expr: ts.Expression): string | undefined {
+function extractColumnName(
+  expr: ts.Expression,
+  propertyKey: string,
+  casingFn: (name: string) => string,
+): string | undefined {
   // Handle chained calls like serial("id").primaryKey()
   let current = expr;
 
@@ -191,9 +318,13 @@ function extractColumnName(expr: ts.Expression): string | undefined {
       // This is a method call like .primaryKey(), go deeper
       current = current.expression.expression;
     } else if (ts.isIdentifier(current.expression)) {
-      // This is the base call like serial("id")
+      // This is the base call like serial("id") or integer()
       const firstArg = current.arguments[0];
-      if (firstArg && ts.isStringLiteral(firstArg)) {
+      if (!firstArg || ts.isObjectLiteralExpression(firstArg)) {
+        // No explicit name: Drizzle derives the column name from the property key
+        return casingFn(propertyKey);
+      }
+      if (ts.isStringLiteral(firstArg)) {
         return firstArg.text;
       }
       return undefined;


### PR DESCRIPTION
## 概要

Drizzle v1 の casing helper (`snakeCase.table(...)` など) で定義したテーブルの JSDoc コメントが、生成される DBML / Markdown から抜け落ちる問題を修正します。

Closes #157

原因は 2 つありました。

1. `src/parser/comments.ts` の `isTableDefinitionFunction` が `pgTable` / `mysqlTable` / `sqliteTable` しか許可しておらず、`snakeCase.table(...)` のようなメソッド呼び出し (`table`) が丸ごとスキップされていた
2. `extractColumnName` がカラム定義の第一引数に文字列リテラルを要求しており、`code: integer()` のように名前を省略したカラムのコメントは (`pgTable` でも) 落ちていた。issue の再現例はこの両方に該当するため、1 だけ直してもカラムコメントは出ません

## 変更内容

- テーブル定義として `table` / `withRLS` メソッド呼び出しも受け付けるようにした
  - `snakeCase.table`, `camelCase.table`, `pgSchema("auth").table`, `pgTable.withRLS`, `snakeCase.table.withRLS` が対象
- 名前省略カラム (`integer()`, `varchar({ length: 255 })` など) は、プロパティキーにテーブル helper の casing を適用して DB カラム名を導出するようにした
  - 変換には `drizzle-orm/casing` の `getCasingFn` を使い、実行時の `column.name` と一致させている (`snakeCase.table` で `authorId: integer()` → `author_id`)
  - 明示的な名前 (`integer("owner")`) がある場合は従来どおりそちらを優先
  - 第一引数が変数などで名前を静的に特定できないカラムは従来どおりスキップ
- casing の解決は呼び出し元の receiver チェーンを辿る。`import { snakeCase as sc }` の alias と `const auth = snakeCase.schema("auth")` のような schema 変数も解決できるよう、全ファイルを先に走査する 2 パス構成にした (ファイルの並び順に依存しない)

## テスト

- [x] `src/parser/comments.test.ts` に 13 件追加 (snake_case / camelCase 変換、明示名の優先、import alias、withRLS、MySQL / SQLite の helper、schema 変数の別ファイル解決、名前省略カラム、動的な名前のスキップ)
- [x] `src/generator/pg.test.ts` に、実際の `snakeCase.table` オブジェクトとソースを組み合わせた end-to-end テストを 1 件追加
- [x] `pnpm format:check && pnpm lint && pnpm typecheck && pnpm test:run` (215 件) がすべて成功
- [x] `pnpm test:integration` (55 件) がすべて成功
- [x] `pnpm generate:examples` を実行しても既存の example 出力に差分なし
- [x] issue の再現スキーマを CLI (`-f dbml` / `-f markdown --single-file`) で実行し、テーブル Note とカラム note が出力されることを確認

## 補足

以下は今回の範囲外のままです。

- コールバック形式のカラム定義 `pgTable("x", (t) => ({ id: t.integer() }))`
- `pgTableCreator(...)` で作った独自 helper 経由のテーブル


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved comment extraction for Drizzle tables and schemas using casing helpers.
  * Added support for table helpers, row-level security variants, schema helpers, import aliases, and multiple SQL dialects.
  * Automatically derives names for columns without explicit names while respecting configured casing.
  * Supports resolving schema and casing definitions across files.

* **Tests**
  * Added coverage for generated DBML table and column comments across supported helper patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->