### PR TITLE
fix: detect and document PostgreSQL enums across duplicate drizzle-orm (#158)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -10,6 +10,7 @@ Drizzle ORM スキーマから DBML と Markdown ドキュメントを生成す�
 - **ディレクトリインポート対応**: ディレクトリ内のすべてのスキーマファイルを自動インポート
 - **拡張子不要**: 拡張子なしのインポートに対応 (例: `import { users } from './users'`)
 - **JSDoc コメント**: 自動的に DBML の Note 句に変換
+- **PostgreSQL Enum**: `pgEnum` 定義をドキュメント化 (enum 本体と各値の JSDoc コメントも抽出)
 - **リレーション対応**: `relations()` または `defineRelations()` から参照を生成
 - **Watch モード**: ファイル変更時に自動再生成
 - **複数の出力形式**: Markdown (デフォルト) および ER 図付き DBML
@@ -57,6 +58,7 @@ drizzle-docs generate ./src/db/schema.ts -d postgresql -f dbml -o schema.dbml
 #### Markdown 形式 (デフォルト)
 
 デフォルトの出力形式は **Markdown** で、ER 図付きの複数ファイルを生成します。
+PostgreSQL スキーマに `pgEnum` 定義がある場合は `enums.md` も生成され、`README.md` からリンクされます。
 
 **Markdown 形式固有のオプション:**
 
@@ -150,6 +152,40 @@ Table users {
 | ---- | ------ | -------- | ------- | ---------- |
 | id   | serial | No       |         | ユーザーID |
 | name | text   | No       |         | ユーザー名 |
+```
+
+### Enum コメント (PostgreSQL)
+
+`pgEnum` 定義と各値に付けた JSDoc コメントも抽出されます。
+enum 定義が解析されるように、スキーマの**ディレクトリ** (または enum を定義しているファイル) をソースに指定してください。
+
+```typescript
+/** 注文のライフサイクル状態 */
+export const orderStatusEnum = pgEnum("order_status", [
+  /** 注文済み・未決済 */
+  "pending",
+  /** 決済確認済み */
+  "paid",
+]);
+```
+
+```dbml
+// 注文のライフサイクル状態
+Enum "order_status" {
+  pending [note: '注文済み・未決済']
+  paid [note: '決済確認済み']
+}
+```
+
+```markdown
+## order_status
+
+注文のライフサイクル状態
+
+| Value   | Comment          |
+| ------- | ---------------- |
+| pending | 注文済み・未決済 |
+| paid    | 決済確認済み     |
 ```
 
 詳細なサンプル出力は [examples/](./examples/) を参照してください。

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ CLI tool to generate DBML and Markdown documentation from Drizzle ORM schemas. E
 - **Directory Import Support**: Import all schema files from a directory
 - **No File Extension Required**: Works with extensionless imports (e.g., `import { users } from './users'`)
 - **JSDoc Comments**: Automatically extracts and converts to DBML Notes
+- **PostgreSQL Enums**: Documents `pgEnum` definitions, including JSDoc comments on the enum and each value
 - **Relations Support**: Generate refs from `relations()` or `defineRelations()`
 - **Watch Mode**: Auto-regenerate on file changes
 - **Multiple Output Formats**: Markdown (default) and DBML with ER diagrams
@@ -57,6 +58,7 @@ drizzle-docs generate ./src/db/schema.ts -d postgresql -f dbml -o schema.dbml
 #### Markdown Format (Default)
 
 The default output format is **Markdown**, which generates multiple files with an ER diagram.
+For PostgreSQL schemas with `pgEnum` definitions, an `enums.md` file is generated and linked from `README.md`.
 
 **Options specific to Markdown format:**
 
@@ -150,6 +152,40 @@ Users table
 | ---- | ------ | -------- | ------- | --------- |
 | id   | serial | No       |         | User ID   |
 | name | text   | No       |         | User name |
+```
+
+### Enum Comments (PostgreSQL)
+
+JSDoc comments on `pgEnum` definitions and on each value are extracted as well.
+Pass the schema **directory** (or the file that defines the enum) as the source so the enum definition is parsed.
+
+```typescript
+/** Lifecycle status of an order */
+export const orderStatusEnum = pgEnum("order_status", [
+  /** Order has been placed but not yet paid */
+  "pending",
+  /** Payment confirmed */
+  "paid",
+]);
+```
+
+```dbml
+// Lifecycle status of an order
+Enum "order_status" {
+  pending [note: 'Order has been placed but not yet paid']
+  paid [note: 'Payment confirmed']
+}
+```
+
+```markdown
+## order_status
+
+Lifecycle status of an order
+
+| Value   | Comment                                |
+| ------- | -------------------------------------- |
+| pending | Order has been placed but not yet paid |
+| paid    | Payment confirmed                      |
 ```
 
 See [examples/](./examples/) for more detailed output samples.

--- a/examples/pg/v0/markdown/README.md
+++ b/examples/pg/v0/markdown/README.md
@@ -4,11 +4,19 @@
 |------|---------|---------|
 | [comments](./comments.md) | 5 | Comments on posts |
 | [coupons](./coupons.md) | 3 | Discount coupons |
-| [orders](./orders.md) | 5 | Orders with optional coupon reference |
+| [orders](./orders.md) | 6 | Orders with optional coupon reference |
 | [post_tags](./post_tags.md) | 2 | Join table for many-to-many relationship between posts and tags |
 | [posts](./posts.md) | 6 | Blog posts created by users |
 | [tags](./tags.md) | 3 | Tags for categorizing posts |
 | [users](./users.md) | 5 | User accounts table storing basic user information |
+
+---
+
+# Enums
+
+| Name | Values | Comment |
+|------|--------|---------|
+| [order_status](./enums.md#order_status) | pending, paid, shipped, cancelled | Lifecycle status of an order |
 
 ---
 
@@ -40,6 +48,7 @@ erDiagram
         uuid id PK "Auto-generated unique identifier"
         int user_id FK "ID of the user who placed the order"
         uuid coupon_id FK "Optional coupon applied to this order (nullable foreign key)"
+        order_status status "Current status of the order"
         int total_cents "Total order amount in cents"
         timestamp created_at "Timestamp when the order was created"
     }

--- a/examples/pg/v0/markdown/enums.md
+++ b/examples/pg/v0/markdown/enums.md
@@ -1,0 +1,12 @@
+# Enums
+
+## order_status
+
+Lifecycle status of an order
+
+| Value | Comment |
+|-------|---------|
+| pending | Order has been placed but not yet paid |
+| paid | Payment confirmed |
+| shipped | Order has been handed to the carrier |
+| cancelled | Order was cancelled by the user or the shop |

--- a/examples/pg/v0/markdown/orders.md
+++ b/examples/pg/v0/markdown/orders.md
@@ -11,6 +11,7 @@ Orders with optional coupon reference
 | **id** | uuid | `gen_random_uuid()` | NO | - | - | Auto-generated unique identifier |
 | user_id | integer | - | NO | - | [users.id](./users.md) | ID of the user who placed the order |
 | coupon_id | uuid | - | YES | - | [coupons.id](./coupons.md) | Optional coupon applied to this order (nullable foreign key) |
+| status | order_status | `'pending'` | NO | - | - | Current status of the order |
 | total_cents | integer | - | NO | - | - | Total order amount in cents |
 | created_at | timestamp | `now()` | YES | - | - | Timestamp when the order was created |
 

--- a/examples/pg/v0/schema.dbml
+++ b/examples/pg/v0/schema.dbml
@@ -1,3 +1,11 @@
+// Lifecycle status of an order
+Enum "order_status" {
+  pending [note: 'Order has been placed but not yet paid']
+  paid [note: 'Payment confirmed']
+  shipped [note: 'Order has been handed to the carrier']
+  cancelled [note: 'Order was cancelled by the user or the shop']
+}
+
 Table "comments" {
   "id" serial [primary key, not null, increment, note: 'Auto-generated unique identifier']
   "body" text [not null, note: 'Comment text']
@@ -20,6 +28,7 @@ Table "orders" {
   "id" uuid [primary key, not null, default: `gen_random_uuid()`, note: 'Auto-generated unique identifier']
   "user_id" integer [not null, note: 'ID of the user who placed the order']
   "coupon_id" uuid [note: 'Optional coupon applied to this order (nullable foreign key)']
+  "status" order_status [not null, default: 'pending', note: 'Current status of the order']
   "total_cents" integer [not null, note: 'Total order amount in cents']
   "created_at" timestamp [default: `now()`, note: 'Timestamp when the order was created']
 

--- a/examples/pg/v0/schema.ts
+++ b/examples/pg/v0/schema.ts
@@ -11,10 +11,12 @@
  * - JSDoc comments (table and column)
  * - Relations definitions
  * - Nullable foreign keys
+ * - PostgreSQL enum with JSDoc comments on the enum and its values
  */
 
 import {
   pgTable,
+  pgEnum,
   serial,
   text,
   varchar,
@@ -146,6 +148,18 @@ export const coupons = pgTable("coupons", {
   discountPercent: integer("discount_percent").notNull(),
 });
 
+/** Lifecycle status of an order */
+export const orderStatusEnum = pgEnum("order_status", [
+  /** Order has been placed but not yet paid */
+  "pending",
+  /** Payment confirmed */
+  "paid",
+  /** Order has been handed to the carrier */
+  "shipped",
+  /** Order was cancelled by the user or the shop */
+  "cancelled",
+]);
+
 /** Orders with optional coupon reference */
 export const orders = pgTable(
   "orders",
@@ -156,6 +170,8 @@ export const orders = pgTable(
     userId: integer("user_id").notNull(),
     /** Optional coupon applied to this order (nullable foreign key) */
     couponId: uuid("coupon_id"),
+    /** Current status of the order */
+    status: orderStatusEnum("status").default("pending").notNull(),
     /** Total order amount in cents */
     totalCents: integer("total_cents").notNull(),
     /** Timestamp when the order was created */

--- a/examples/pg/v1/markdown/README.md
+++ b/examples/pg/v1/markdown/README.md
@@ -4,11 +4,19 @@
 |------|---------|---------|
 | [comments](./comments.md) | 5 | Comments on posts |
 | [coupons](./coupons.md) | 3 | Discount coupons |
-| [orders](./orders.md) | 5 | Orders with optional coupon reference |
+| [orders](./orders.md) | 6 | Orders with optional coupon reference |
 | [post_tags](./post_tags.md) | 2 | Join table for many-to-many relationship between posts and tags |
 | [posts](./posts.md) | 6 | Blog posts created by users |
 | [tags](./tags.md) | 3 | Tags for categorizing posts |
 | [users](./users.md) | 5 | User accounts table storing basic user information |
+
+---
+
+# Enums
+
+| Name | Values | Comment |
+|------|--------|---------|
+| [order_status](./enums.md#order_status) | pending, paid, shipped, cancelled | Lifecycle status of an order |
 
 ---
 
@@ -40,6 +48,7 @@ erDiagram
         uuid id PK "Auto-generated unique identifier"
         int user_id FK "ID of the user who placed the order"
         uuid coupon_id FK "Optional coupon applied to this order (nullable foreign key)"
+        order_status status "Current status of the order"
         int total_cents "Total order amount in cents"
         timestamp created_at "Timestamp when the order was created"
     }

--- a/examples/pg/v1/markdown/enums.md
+++ b/examples/pg/v1/markdown/enums.md
@@ -1,0 +1,12 @@
+# Enums
+
+## order_status
+
+Lifecycle status of an order
+
+| Value | Comment |
+|-------|---------|
+| pending | Order has been placed but not yet paid |
+| paid | Payment confirmed |
+| shipped | Order has been handed to the carrier |
+| cancelled | Order was cancelled by the user or the shop |

--- a/examples/pg/v1/markdown/orders.md
+++ b/examples/pg/v1/markdown/orders.md
@@ -11,6 +11,7 @@ Orders with optional coupon reference
 | **id** | uuid | `gen_random_uuid()` | NO | - | - | Auto-generated unique identifier |
 | user_id | integer | - | NO | - | [users.id](./users.md) | ID of the user who placed the order |
 | coupon_id | uuid | - | YES | - | [coupons.id](./coupons.md) | Optional coupon applied to this order (nullable foreign key) |
+| status | order_status | `'pending'` | NO | - | - | Current status of the order |
 | total_cents | integer | - | NO | - | - | Total order amount in cents |
 | created_at | timestamp | `now()` | YES | - | - | Timestamp when the order was created |
 

--- a/examples/pg/v1/schema.dbml
+++ b/examples/pg/v1/schema.dbml
@@ -1,3 +1,11 @@
+// Lifecycle status of an order
+Enum "order_status" {
+  pending [note: 'Order has been placed but not yet paid']
+  paid [note: 'Payment confirmed']
+  shipped [note: 'Order has been handed to the carrier']
+  cancelled [note: 'Order was cancelled by the user or the shop']
+}
+
 Table "comments" {
   "id" serial [primary key, not null, increment, note: 'Auto-generated unique identifier']
   "body" text [not null, note: 'Comment text']
@@ -20,6 +28,7 @@ Table "orders" {
   "id" uuid [primary key, not null, default: `gen_random_uuid()`, note: 'Auto-generated unique identifier']
   "user_id" integer [not null, note: 'ID of the user who placed the order']
   "coupon_id" uuid [note: 'Optional coupon applied to this order (nullable foreign key)']
+  "status" order_status [not null, default: 'pending', note: 'Current status of the order']
   "total_cents" integer [not null, note: 'Total order amount in cents']
   "created_at" timestamp [default: `now()`, note: 'Timestamp when the order was created']
 

--- a/examples/pg/v1/schema.ts
+++ b/examples/pg/v1/schema.ts
@@ -9,10 +9,12 @@
  * - Cleaner, more modern relation definitions
  * - Supports bidirectional relation queries
  * - Includes nullable foreign key examples
+ * - Includes a PostgreSQL enum with JSDoc comments on the enum and its values
  */
 
 import {
   pgTable,
+  pgEnum,
   serial,
   text,
   varchar,
@@ -144,6 +146,18 @@ export const coupons = pgTable("coupons", {
   discountPercent: integer("discount_percent").notNull(),
 });
 
+/** Lifecycle status of an order */
+export const orderStatusEnum = pgEnum("order_status", [
+  /** Order has been placed but not yet paid */
+  "pending",
+  /** Payment confirmed */
+  "paid",
+  /** Order has been handed to the carrier */
+  "shipped",
+  /** Order was cancelled by the user or the shop */
+  "cancelled",
+]);
+
 /** Orders with optional coupon reference */
 export const orders = pgTable(
   "orders",
@@ -154,6 +168,8 @@ export const orders = pgTable(
     userId: integer("user_id").notNull(),
     /** Optional coupon applied to this order (nullable foreign key) */
     couponId: uuid("coupon_id"),
+    /** Current status of the order */
+    status: orderStatusEnum("status").default("pending").notNull(),
     /** Total order amount in cents */
     totalCents: integer("total_cents").notNull(),
     /** Timestamp when the order was created */

--- a/src/cli/cli.integration.markdown.test.ts
+++ b/src/cli/cli.integration.markdown.test.ts
@@ -105,6 +105,64 @@ describe("Markdown Format Output", () => {
     rmSync(outputDir, { recursive: true, force: true });
   });
 
+  it("should output enums.md and link it from README.md in multi-file output (#158)", async () => {
+    const outputDir = join(TEST_OUTPUT_DIR, "multi-file-enums-output");
+
+    const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+      format: "markdown",
+      output: outputDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+
+    const enumsPath = join(outputDir, "enums.md");
+    expect(existsSync(enumsPath)).toBe(true);
+
+    const enumsContent = readFileSync(enumsPath, "utf-8");
+    expect(enumsContent).toContain("# Enums");
+    expect(enumsContent).toContain("## order_status");
+    expect(enumsContent).toContain("Lifecycle status of an order");
+    expect(enumsContent).toContain("| Value | Comment |");
+    expect(enumsContent).toContain("| pending | Order has been placed but not yet paid |");
+    expect(enumsContent).toContain("| cancelled | Order was cancelled by the user or the shop |");
+
+    const readmeContent = readFileSync(join(outputDir, "README.md"), "utf-8");
+    expect(readmeContent).toContain("# Enums");
+    expect(readmeContent).toContain("[order_status](./enums.md#order_status)");
+
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it("should not output enums.md when the schema has no enums", async () => {
+    const outputDir = join(TEST_OUTPUT_DIR, "multi-file-no-enums-output");
+
+    const result = await runGenerate(MYSQL_SCHEMA_V1, "mysql", {
+      format: "markdown",
+      output: outputDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(join(outputDir, "README.md"))).toBe(true);
+    expect(existsSync(join(outputDir, "enums.md"))).toBe(false);
+
+    const readmeContent = readFileSync(join(outputDir, "README.md"), "utf-8");
+    expect(readmeContent).not.toContain("# Enums");
+
+    rmSync(outputDir, { recursive: true, force: true });
+  });
+
+  it("should include enum comments in single-file Markdown output", async () => {
+    const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
+      format: "markdown",
+      singleFile: true,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("## order_status");
+    expect(result.stdout).toContain("Lifecycle status of an order");
+    expect(result.stdout).toContain("| paid | Payment confirmed |");
+  });
+
   it("should auto-detect defineRelations() and generate Markdown with relations", async () => {
     const result = await runGenerate(PG_SCHEMA_V1, "postgresql", {
       format: "markdown",

--- a/src/cli/cli.integration.postgresql.test.ts
+++ b/src/cli/cli.integration.postgresql.test.ts
@@ -2,7 +2,8 @@
  * PostgreSQL CLI Integration Tests
  */
 
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { cpSync, realpathSync } from "node:fs";
 import { runGenerate } from "../test-utils/cli-runner.js";
 import {
   hasAllTables,
@@ -20,8 +21,10 @@ import {
   EXPECTED_TABLES,
   TEST_OUTPUT_DIR,
   existsSync,
+  mkdirSync,
   rmSync,
   readFileSync,
+  writeFileSync,
   join,
 } from "./integration-test-utils.js";
 
@@ -90,6 +93,17 @@ describe("PostgreSQL v1 (defineRelations())", () => {
     expect(hasTableNote(result.stdout, "posts", "Blog posts", '"')).toBe(true);
   });
 
+  it("should generate enum definitions with JSDoc comments", async () => {
+    const result = await runGenerate(PG_SCHEMA_V1, "postgresql", { format: "dbml" });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("// Lifecycle status of an order");
+    expect(result.stdout).toContain('Enum "order_status" {');
+    expect(result.stdout).toContain("pending [note: 'Order has been placed but not yet paid']");
+    expect(result.stdout).toContain("paid [note: 'Payment confirmed']");
+    expect(result.stdout).toContain('"status" order_status [not null');
+  });
+
   it("should auto-detect defineRelations() and generate relations", async () => {
     const result = await runGenerate(PG_SCHEMA_V1, "postgresql", { format: "dbml" });
 
@@ -116,5 +130,113 @@ describe("PostgreSQL v1 (defineRelations())", () => {
     expect(hasAllTables(fileContent, EXPECTED_TABLES, '"')).toBe(true);
 
     rmSync(outputPath, { force: true });
+  });
+});
+
+/**
+ * Regression tests for #158: the schema under test resolves its own copy of
+ * drizzle-orm (copied into a nested node_modules), so the column classes are
+ * NOT the same class objects the CLI imports. Enum detection must rely on
+ * drizzle's entityKind brand check instead of instanceof.
+ */
+describe("PostgreSQL enums with a duplicate drizzle-orm copy (#158)", () => {
+  const PROJECT_DIR = join(TEST_OUTPUT_DIR, "duplicate-drizzle-orm");
+  const SCHEMA_DIR = join(PROJECT_DIR, "schema");
+  const REPO_ROOT = join(import.meta.dirname, "../..");
+
+  beforeAll(() => {
+    rmSync(PROJECT_DIR, { recursive: true, force: true });
+    mkdirSync(SCHEMA_DIR, { recursive: true });
+
+    // Copy the real drizzle-orm package (resolving the pnpm symlink) so that
+    // imports from the schema files resolve to a separate module instance.
+    const drizzleOrmSource = realpathSync(join(REPO_ROOT, "node_modules/drizzle-orm"));
+    cpSync(drizzleOrmSource, join(PROJECT_DIR, "node_modules/drizzle-orm"), {
+      recursive: true,
+      dereference: true,
+    });
+
+    writeFileSync(
+      join(SCHEMA_DIR, "enums.ts"),
+      `import { pgEnum } from "drizzle-orm/pg-core";
+
+/** Body type of a bike */
+export const bikeBodyTypeEnum = pgEnum("bike_body_type", [
+  /** No fairing */
+  "naked",
+  /** Dual purpose on/off-road */
+  "onOff",
+  "quadricycle",
+]);
+`,
+    );
+
+    writeFileSync(
+      join(SCHEMA_DIR, "tables.ts"),
+      `import { pgTable, serial } from "drizzle-orm/pg-core";
+import { bikeBodyTypeEnum } from "./enums";
+
+/** Bikes */
+export const bikes = pgTable("bikes", {
+  /** Primary key */
+  id: serial("id").primaryKey(),
+  /** Body type */
+  bodyType: bikeBodyTypeEnum("body_type").notNull(),
+});
+`,
+    );
+  });
+
+  afterAll(() => {
+    rmSync(PROJECT_DIR, { recursive: true, force: true });
+  });
+
+  it("should detect enums and their comments in DBML output", async () => {
+    const result = await runGenerate(SCHEMA_DIR, "postgresql", { format: "dbml" });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain("// Body type of a bike");
+    expect(result.stdout).toContain('Enum "bike_body_type" {');
+    expect(result.stdout).toContain("naked [note: 'No fairing']");
+    expect(result.stdout).toContain("onOff [note: 'Dual purpose on/off-road']");
+    expect(result.stdout).toContain("quadricycle");
+    // Column and table comments must also be found when a directory is passed
+    expect(result.stdout).toContain("\"body_type\" bike_body_type [not null, note: 'Body type']");
+    expect(hasTableNote(result.stdout, "bikes", "Bikes", '"')).toBe(true);
+  });
+
+  it("should skip node_modules when a project directory is passed", async () => {
+    // PROJECT_DIR contains node_modules/drizzle-orm; scanning it must not
+    // try to import files from node_modules
+    const result = await runGenerate(PROJECT_DIR, "postgresql", { format: "dbml" });
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe("");
+    expect(result.stdout).toContain('Enum "bike_body_type" {');
+    expect(result.stdout).toContain('Table "bikes" {');
+    expect(hasTableNote(result.stdout, "bikes", "Bikes", '"')).toBe(true);
+  });
+
+  it("should write enums.md with comments in multi-file Markdown output", async () => {
+    const outputDir = join(PROJECT_DIR, "docs");
+
+    const result = await runGenerate(SCHEMA_DIR, "postgresql", {
+      format: "markdown",
+      output: outputDir,
+    });
+
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(join(outputDir, "bikes.md"))).toBe(true);
+    expect(existsSync(join(outputDir, "enums.md"))).toBe(true);
+
+    const enumsContent = readFileSync(join(outputDir, "enums.md"), "utf-8");
+    expect(enumsContent).toContain("## bike_body_type");
+    expect(enumsContent).toContain("Body type of a bike");
+    expect(enumsContent).toContain("| naked | No fairing |");
+    expect(enumsContent).toContain("| quadricycle | - |");
+
+    const readmeContent = readFileSync(join(outputDir, "README.md"), "utf-8");
+    expect(readmeContent).toContain("[bike_body_type](./enums.md#bike_body_type)");
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -53,6 +53,9 @@ program.name("drizzle-docs").description(packageJson.description).version(packag
 type Dialect = "postgresql" | "mysql" | "sqlite";
 type OutputFormat = "dbml" | "markdown";
 
+/** File name for enum documentation in multi-file Markdown output */
+const ENUMS_FILE_NAME = "enums.md";
+
 interface GenerateCommandOptions {
   output?: string;
   dialect: Dialect;
@@ -97,7 +100,11 @@ function getGeneratorClass(dialect: Dialect) {
 /**
  * Check if output directory has existing files
  */
-function hasExistingFiles(outputDir: string, tableNames: string[]): string[] {
+function hasExistingFiles(
+  outputDir: string,
+  tableNames: string[],
+  hasEnums: boolean = false,
+): string[] {
   const existingFiles: string[] = [];
 
   if (!existsSync(outputDir)) {
@@ -107,6 +114,13 @@ function hasExistingFiles(outputDir: string, tableNames: string[]): string[] {
   const readmePath = join(outputDir, "README.md");
   if (existsSync(readmePath)) {
     existingFiles.push(readmePath);
+  }
+
+  if (hasEnums) {
+    const enumsPath = join(outputDir, ENUMS_FILE_NAME);
+    if (existsSync(enumsPath)) {
+      existingFiles.push(enumsPath);
+    }
   }
 
   for (const tableName of tableNames) {
@@ -173,6 +187,11 @@ function findSchemaFiles(dirPath: string): string[] {
       const fullPath = join(dirPath, entry.name);
 
       if (entry.isDirectory()) {
+        // Skip dependencies and hidden directories (e.g. node_modules, .git):
+        // they never contain user schema files and importing them can fail
+        if (entry.name === "node_modules" || entry.name.startsWith(".")) {
+          continue;
+        }
         // Recursively search subdirectories
         files.push(...findSchemaFiles(fullPath));
       } else if (entry.isFile() && /\.(ts|js|mts|mjs|cts|cjs)$/.test(entry.name)) {
@@ -220,14 +239,14 @@ function resolveSchemaPath(schema: string): string[] {
  */
 function generateDbmlOutput(
   mergedSchema: Record<string, unknown>,
-  schemaPaths: string[],
+  sourcePath: string,
   options: GenerateCommandOptions,
 ): string {
   const generate = getGenerateFunction(options.dialect);
   return (
     generate({
       schema: mergedSchema,
-      source: schemaPaths[0],
+      source: sourcePath,
     }) || ""
   );
 }
@@ -272,6 +291,13 @@ function writeMarkdownMultipleFiles(
   const index = markdownFormatter.generateIndex(intermediateSchema);
   let readme = `${index}\n`;
 
+  // Add enums index to README and write enums.md (PostgreSQL enums)
+  const hasEnums = intermediateSchema.enums.length > 0;
+  if (hasEnums) {
+    const enumsIndex = markdownFormatter.generateEnumsIndex(intermediateSchema.enums);
+    readme += `\n---\n\n${enumsIndex}\n`;
+  }
+
   // Add ER diagram to README unless disabled
   if (options.erDiagram) {
     const mermaidFormatter = new MermaidErDiagramFormatter({
@@ -282,6 +308,12 @@ function writeMarkdownMultipleFiles(
   }
 
   writeFileSync(join(outputDir, "README.md"), readme, "utf-8");
+
+  // Write enums.md with all enum definitions
+  if (hasEnums) {
+    const enumsDoc = markdownFormatter.generateEnumsSection(intermediateSchema.enums);
+    writeFileSync(join(outputDir, ENUMS_FILE_NAME), `${enumsDoc}\n`, "utf-8");
+  }
 
   // Write individual table files
   for (const table of intermediateSchema.tables) {
@@ -329,15 +361,16 @@ async function runGenerate(schema: string, options: GenerateCommandOptions): Pro
       }
     }
 
+    // For multiple files, pass the directory path to extract comments from all files
+    const firstFilePath = schemaPaths[0];
+    if (!firstFilePath) {
+      throw new Error("No schema files found");
+    }
+    const sourcePath = schemaPaths.length === 1 ? firstFilePath : dirname(firstFilePath);
+
     if (options.format === "markdown") {
       // Generate Markdown format
       const GeneratorClass = getGeneratorClass(options.dialect);
-      // For multiple files, pass the directory path to extract comments from all files
-      const firstFilePath = schemaPaths[0];
-      if (!firstFilePath) {
-        throw new Error("No schema files found");
-      }
-      const sourcePath = schemaPaths.length === 1 ? firstFilePath : dirname(firstFilePath);
       const generator = new GeneratorClass({
         schema: mergedSchema,
         source: sourcePath,
@@ -371,7 +404,11 @@ async function runGenerate(schema: string, options: GenerateCommandOptions): Pro
           // Check for existing files if --force is not specified
           if (!options.force) {
             const tableNames = intermediateSchema.tables.map((t) => t.name);
-            const existingFiles = hasExistingFiles(options.output, tableNames);
+            const existingFiles = hasExistingFiles(
+              options.output,
+              tableNames,
+              intermediateSchema.enums.length > 0,
+            );
             if (existingFiles.length > 0) {
               console.error(
                 `Error: The following files already exist:\n${existingFiles.map((f) => `  - ${f}`).join("\n")}\nUse --force to overwrite existing files.`,
@@ -385,7 +422,7 @@ async function runGenerate(schema: string, options: GenerateCommandOptions): Pro
       }
     } else {
       // Generate DBML format
-      const dbml = generateDbmlOutput(mergedSchema, schemaPaths, options);
+      const dbml = generateDbmlOutput(mergedSchema, sourcePath, options);
 
       if (options.output) {
         // Check for existing file if --force is not specified

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -30,6 +30,7 @@ import { register } from "tsx/esm/api";
 import { register as registerCjs } from "tsx/cjs/api";
 import type { IntermediateSchema } from "../types";
 import { resolveSchemaExports } from "./resolve-schema-exports";
+import { isIgnoredDirectory } from "../parser/files";
 
 // Register both ESM and CJS tsx loader hooks.
 // ESM hooks handle import() calls, CJS hooks handle require() calls.
@@ -100,11 +101,7 @@ function getGeneratorClass(dialect: Dialect) {
 /**
  * Check if output directory has existing files
  */
-function hasExistingFiles(
-  outputDir: string,
-  tableNames: string[],
-  hasEnums: boolean = false,
-): string[] {
+function hasExistingFiles(outputDir: string, tableNames: string[], hasEnums: boolean): string[] {
   const existingFiles: string[] = [];
 
   if (!existsSync(outputDir)) {
@@ -187,9 +184,7 @@ function findSchemaFiles(dirPath: string): string[] {
       const fullPath = join(dirPath, entry.name);
 
       if (entry.isDirectory()) {
-        // Skip dependencies and hidden directories (e.g. node_modules, .git):
-        // they never contain user schema files and importing them can fail
-        if (entry.name === "node_modules" || entry.name.startsWith(".")) {
+        if (isIgnoredDirectory(entry.name)) {
           continue;
         }
         // Recursively search subdirectories
@@ -208,9 +203,19 @@ function findSchemaFiles(dirPath: string): string[] {
 }
 
 /**
+ * Resolved schema input
+ */
+interface ResolvedSchema {
+  /** Schema files to import */
+  schemaPaths: string[];
+  /** The resolved file or directory the user passed, used for comment/relation extraction */
+  sourcePath: string;
+}
+
+/**
  * Resolve schema path (file or directory)
  */
-function resolveSchemaPath(schema: string): string[] {
+function resolveSchemaPath(schema: string): ResolvedSchema {
   const schemaPath = resolve(process.cwd(), schema);
 
   // Check if path exists
@@ -227,11 +232,11 @@ function resolveSchemaPath(schema: string): string[] {
       console.error(`Error: No schema files found in directory: ${schemaPath}`);
       process.exit(1);
     }
-    return schemaFiles;
+    return { schemaPaths: schemaFiles, sourcePath: schemaPath };
   }
 
   // Single file
-  return [schemaPath];
+  return { schemaPaths: [schemaPath], sourcePath: schemaPath };
 }
 
 /**
@@ -336,7 +341,7 @@ function writeSingleMarkdownFile(content: string, outputPath: string): void {
  * Run the generate command
  */
 async function runGenerate(schema: string, options: GenerateCommandOptions): Promise<void> {
-  const schemaPaths = resolveSchemaPath(schema);
+  const { schemaPaths, sourcePath } = resolveSchemaPath(schema);
 
   try {
     // Merge all schema modules
@@ -360,13 +365,6 @@ async function runGenerate(schema: string, options: GenerateCommandOptions): Pro
         throw error;
       }
     }
-
-    // For multiple files, pass the directory path to extract comments from all files
-    const firstFilePath = schemaPaths[0];
-    if (!firstFilePath) {
-      throw new Error("No schema files found");
-    }
-    const sourcePath = schemaPaths.length === 1 ? firstFilePath : dirname(firstFilePath);
 
     if (options.format === "markdown") {
       // Generate Markdown format

--- a/src/formatter/dbml.test.ts
+++ b/src/formatter/dbml.test.ts
@@ -502,6 +502,82 @@ describe("DbmlFormatter", () => {
       expect(dbml).toContain("pending");
     });
 
+    it("should include enum comments as line comment and value notes", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [],
+        relations: [],
+        enums: [
+          {
+            name: "user_status",
+            values: ["active", "inactive", "pending"],
+            comment: "Account status\nSecond line",
+            valueComments: {
+              active: "Account is active",
+              inactive: "It's disabled",
+            },
+          },
+        ],
+      };
+
+      const formatter = new DbmlFormatter();
+      const dbml = formatter.format(schema);
+
+      expect(dbml).toContain('// Account status\n// Second line\nEnum "user_status" {');
+      expect(dbml).toContain("  active [note: 'Account is active']");
+      expect(dbml).toContain("  inactive [note: 'It\\'s disabled']");
+      expect(dbml).toContain("  pending\n");
+      expect(dbml).not.toContain("Note: 'Account status'");
+    });
+
+    it("should quote enum values that are not plain identifiers", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [],
+        relations: [],
+        enums: [
+          {
+            name: "bike_body_type",
+            values: ["naked", "on-off", "in progress", 'say "hi"', "日本語", "1st"],
+            valueComments: { "on-off": "Dual purpose" },
+          },
+        ],
+      };
+
+      const formatter = new DbmlFormatter();
+      const dbml = formatter.format(schema);
+
+      expect(dbml).toContain("  naked\n");
+      expect(dbml).toContain("  \"on-off\" [note: 'Dual purpose']");
+      expect(dbml).toContain('  "in progress"\n');
+      expect(dbml).toContain('  "say \\"hi\\""\n');
+      expect(dbml).toContain("  日本語\n");
+      expect(dbml).toContain("  1st\n");
+    });
+
+    it("should omit enum comments when includeComments is false", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [],
+        relations: [],
+        enums: [
+          {
+            name: "user_status",
+            values: ["active", "inactive"],
+            comment: "Account status",
+            valueComments: { active: "Account is active" },
+          },
+        ],
+      };
+
+      const formatter = new DbmlFormatter({ includeComments: false });
+      const dbml = formatter.format(schema);
+
+      expect(dbml).not.toContain("// Account status");
+      expect(dbml).not.toContain("note:");
+      expect(dbml).toContain('Enum "user_status" {\n  active\n  inactive\n}');
+    });
+
     it("should include table comments as Note", () => {
       const schema: IntermediateSchema = {
         databaseType: "postgresql",

--- a/src/formatter/dbml.ts
+++ b/src/formatter/dbml.ts
@@ -345,7 +345,7 @@ export class DbmlFormatter implements OutputFormatter {
    * DBML uses double quotes for all database types
    */
   private escapeName(name: string): string {
-    return `"${name}"`;
+    return this.quote(name);
   }
 
   /**
@@ -359,6 +359,13 @@ export class DbmlFormatter implements OutputFormatter {
     if (/^[\p{L}\p{N}_]+$/u.test(value)) {
       return value;
     }
+    return this.quote(value);
+  }
+
+  /**
+   * Wrap a value in DBML double quotes, escaping embedded backslashes and quotes
+   */
+  private quote(value: string): string {
     return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
 

--- a/src/formatter/dbml.ts
+++ b/src/formatter/dbml.ts
@@ -68,13 +68,28 @@ export class DbmlFormatter implements OutputFormatter {
 
   /**
    * Format an enum definition to DBML
+   *
+   * Value comments are emitted as `[note: '...']` attributes.
+   * DBML does not allow a `Note:` element inside an Enum block, so the
+   * enum-level comment is emitted as a `//` line comment above the block.
    */
   private formatEnum(dbml: DbmlBuilder, enumDef: EnumDefinition): void {
     const name = this.escapeName(enumDef.name);
+    if (this.options.includeComments && enumDef.comment) {
+      for (const commentLine of enumDef.comment.split("\n")) {
+        dbml.line(`// ${commentLine}`);
+      }
+    }
     dbml.line(`Enum ${name} {`);
     dbml.indent();
     for (const value of enumDef.values) {
-      dbml.line(value);
+      const valueComment = enumDef.valueComments?.[value];
+      const escapedValue = this.escapeEnumValue(value);
+      if (this.options.includeComments && valueComment) {
+        dbml.line(`${escapedValue} [note: '${this.escapeString(valueComment)}']`);
+      } else {
+        dbml.line(escapedValue);
+      }
     }
     dbml.dedent();
     dbml.line("}");
@@ -331,6 +346,20 @@ export class DbmlFormatter implements OutputFormatter {
    */
   private escapeName(name: string): string {
     return `"${name}"`;
+  }
+
+  /**
+   * Escape an enum value for DBML
+   *
+   * DBML enum values must be identifiers (letters, digits, underscore) or
+   * quoted identifiers. Values containing other characters (e.g. "on-off",
+   * "in progress") are wrapped in double quotes.
+   */
+  private escapeEnumValue(value: string): string {
+    if (/^[\p{L}\p{N}_]+$/u.test(value)) {
+      return value;
+    }
+    return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
   }
 
   /**

--- a/src/formatter/markdown.test.ts
+++ b/src/formatter/markdown.test.ts
@@ -446,6 +446,59 @@ describe("MarkdownFormatter", () => {
       expect(markdown).toContain("| active |");
       expect(markdown).toContain("| inactive |");
       expect(markdown).toContain("| pending |");
+      // No Comment column when no value has a comment
+      expect(markdown).not.toContain("| Value | Comment |");
+    });
+
+    it("should include enum comments and a Comment column for values", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [],
+        relations: [],
+        enums: [
+          {
+            name: "user_status",
+            values: ["active", "inactive", "pending"],
+            comment: "Account status",
+            valueComments: {
+              active: "Account is active",
+              inactive: "Account is disabled",
+            },
+          },
+        ],
+      };
+
+      const formatter = new MarkdownFormatter();
+      const markdown = formatter.format(schema);
+
+      expect(markdown).toContain("## user_status\n\nAccount status\n\n| Value | Comment |");
+      expect(markdown).toContain("|-------|---------|");
+      expect(markdown).toContain("| active | Account is active |");
+      expect(markdown).toContain("| inactive | Account is disabled |");
+      expect(markdown).toContain("| pending | - |");
+    });
+
+    it("should omit enum comments when includeComments is false", () => {
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [],
+        relations: [],
+        enums: [
+          {
+            name: "user_status",
+            values: ["active", "inactive"],
+            comment: "Account status",
+            valueComments: { active: "Account is active" },
+          },
+        ],
+      };
+
+      const formatter = new MarkdownFormatter({ includeComments: false });
+      const markdown = formatter.format(schema);
+
+      expect(markdown).not.toContain("Account status");
+      expect(markdown).not.toContain("Account is active");
+      expect(markdown).toContain("| Value |\n|-------|\n| active |\n| inactive |");
     });
 
     it("should include table comments", () => {
@@ -798,6 +851,73 @@ describe("MarkdownFormatter", () => {
 
       expect(index).toContain("# Tables");
       expect(index).toContain("No tables defined.");
+    });
+  });
+
+  describe("generateEnumsIndex", () => {
+    const enums = [
+      {
+        name: "user_status",
+        values: ["active", "inactive"],
+        comment: "Account status",
+      },
+      {
+        name: "user_role",
+        values: ["admin", "member"],
+      },
+    ];
+
+    it("should generate an enums index with file links", () => {
+      const formatter = new MarkdownFormatter({ linkFormat: "file" });
+      const index = formatter.generateEnumsIndex(enums);
+
+      expect(index).toContain("# Enums");
+      expect(index).toContain("| Name | Values | Comment |");
+      expect(index).toContain(
+        "| [user_status](./enums.md#user_status) | active, inactive | Account status |",
+      );
+      expect(index).toContain("| [user_role](./enums.md#user_role) | admin, member |  |");
+    });
+
+    it("should generate an enums index with anchor links by default", () => {
+      const formatter = new MarkdownFormatter();
+      const index = formatter.generateEnumsIndex(enums);
+
+      expect(index).toContain(
+        "| [user_status](#user_status) | active, inactive | Account status |",
+      );
+    });
+
+    it("should not link names when useRelativeLinks is false", () => {
+      const formatter = new MarkdownFormatter({ useRelativeLinks: false });
+      const index = formatter.generateEnumsIndex(enums);
+
+      expect(index).toContain("| user_status | active, inactive | Account status |");
+      expect(index).not.toContain("](");
+    });
+
+    it("should handle empty enums", () => {
+      const formatter = new MarkdownFormatter();
+      const index = formatter.generateEnumsIndex([]);
+
+      expect(index).toBe("# Enums\n\nNo enums defined.");
+    });
+  });
+
+  describe("generateEnumsSection", () => {
+    it("should be usable standalone for enums.md output", () => {
+      const formatter = new MarkdownFormatter({ linkFormat: "file" });
+      const section = formatter.generateEnumsSection([
+        {
+          name: "user_status",
+          values: ["active"],
+          comment: "Account status",
+          valueComments: { active: "Account is active" },
+        },
+      ]);
+
+      expect(section.startsWith("# Enums\n\n## user_status\n\nAccount status\n\n")).toBe(true);
+      expect(section).toContain("| active | Account is active |");
     });
   });
 

--- a/src/formatter/markdown.ts
+++ b/src/formatter/markdown.ts
@@ -131,6 +131,40 @@ export class MarkdownFormatter implements OutputFormatter {
   }
 
   /**
+   * Generate the enums index section (README.md style)
+   *
+   * Used by multi-file output to link enums from README.md to enums.md.
+   *
+   * @param enums - The enum definitions
+   * @returns Markdown string for the enums index
+   */
+  generateEnumsIndex(enums: EnumDefinition[]): string {
+    const lines: string[] = [];
+
+    lines.push("# Enums");
+    lines.push("");
+
+    if (enums.length === 0) {
+      lines.push("No enums defined.");
+      return lines.join("\n");
+    }
+
+    lines.push("| Name | Values | Comment |");
+    lines.push("|------|--------|---------|");
+
+    for (const enumDef of enums) {
+      const name = this.options.useRelativeLinks ? this.createEnumLink(enumDef.name) : enumDef.name;
+      const values = enumDef.values.map((value) => this.escapeMarkdown(value)).join(", ");
+      const comment =
+        this.options.includeComments && enumDef.comment ? this.escapeMarkdown(enumDef.comment) : "";
+
+      lines.push(`| ${name} | ${values} | ${comment} |`);
+    }
+
+    return lines.join("\n");
+  }
+
+  /**
    * Generate documentation for a single table
    *
    * @param table - The table definition
@@ -308,8 +342,15 @@ export class MarkdownFormatter implements OutputFormatter {
 
   /**
    * Generate documentation for enums
+   *
+   * Each enum gets its own heading, an optional description (from JSDoc),
+   * and a values table. A Comment column is added only when at least one
+   * value has a comment.
+   *
+   * @param enums - The enum definitions
+   * @returns Markdown string for the enums section
    */
-  private generateEnumsSection(enums: EnumDefinition[]): string {
+  generateEnumsSection(enums: EnumDefinition[]): string {
     const lines: string[] = [];
 
     lines.push("# Enums");
@@ -318,10 +359,30 @@ export class MarkdownFormatter implements OutputFormatter {
     for (const enumDef of enums) {
       lines.push(`## ${enumDef.name}`);
       lines.push("");
-      lines.push("| Value |");
-      lines.push("|-------|");
-      for (const value of enumDef.values) {
-        lines.push(`| ${value} |`);
+
+      if (this.options.includeComments && enumDef.comment) {
+        lines.push(this.escapeMarkdownWithBreaks(enumDef.comment));
+        lines.push("");
+      }
+
+      const hasValueComments =
+        this.options.includeComments &&
+        enumDef.values.some((value) => Boolean(enumDef.valueComments?.[value]));
+
+      if (hasValueComments) {
+        lines.push("| Value | Comment |");
+        lines.push("|-------|---------|");
+        for (const value of enumDef.values) {
+          const comment = enumDef.valueComments?.[value];
+          const commentStr = comment ? this.escapeMarkdown(comment) : "-";
+          lines.push(`| ${this.escapeMarkdown(value)} | ${commentStr} |`);
+        }
+      } else {
+        lines.push("| Value |");
+        lines.push("|-------|");
+        for (const value of enumDef.values) {
+          lines.push(`| ${this.escapeMarkdown(value)} |`);
+        }
       }
       lines.push("");
     }
@@ -436,6 +497,19 @@ export class MarkdownFormatter implements OutputFormatter {
       return `[${text}](./${tableName}.md)`;
     }
     return `[${text}](#${tableName})`;
+  }
+
+  /**
+   * Create an enum link based on the configured link format
+   *
+   * In "file" mode, enums are documented together in enums.md
+   */
+  private createEnumLink(enumName: string, displayText?: string): string {
+    const text = displayText || enumName;
+    if (this.options.linkFormat === "file") {
+      return `[${text}](./enums.md#${enumName})`;
+    }
+    return `[${text}](#${enumName})`;
   }
 
   /**

--- a/src/generator/pg.test.ts
+++ b/src/generator/pg.test.ts
@@ -14,6 +14,7 @@ import {
   index,
 } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm/_relations";
+import { entityKind } from "drizzle-orm";
 import type { SchemaComments } from "../parser/comments";
 import { writeFileSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
@@ -1095,6 +1096,177 @@ describe("PgGenerator.toIntermediateSchema with enums", () => {
     const roleEnumDef = schema.enums.find((e: { name: string }) => e.name === "role");
     expect(roleEnumDef).toBeDefined();
     expect(roleEnumDef.values).toEqual(["admin", "user", "guest"]);
+  });
+
+  it("should extract object-form enums (PgEnumObjectColumn)", async () => {
+    const { pgEnum } = await import("drizzle-orm/pg-core");
+
+    const statusEnum = pgEnum("status", { Active: "active", Inactive: "inactive" });
+
+    const users = pgTable("users", {
+      id: serial("id").primaryKey(),
+      status: statusEnum("status").notNull(),
+    });
+
+    const generator = new PgGenerator({ schema: { users, statusEnum } });
+    const schema = generator.toIntermediateSchema();
+
+    expect(schema.enums).toHaveLength(1);
+    expect(schema.enums[0].name).toBe("status");
+    expect(schema.enums[0].values).toEqual(["active", "inactive"]);
+  });
+
+  it("should detect enum columns from a different drizzle-orm module instance (#158)", async () => {
+    const { PgColumn, PgEnumColumn } = await import("drizzle-orm/pg-core");
+
+    // Simulate a PgEnumColumn class coming from another copy of drizzle-orm:
+    // it carries the same entityKind brand but is not the same class object,
+    // so `instanceof PgEnumColumn` is false while drizzle's `is()` is true.
+    class ForeignPgEnumColumn extends PgColumn {
+      static override readonly [entityKind]: string = "PgEnumColumn";
+      readonly enum = { enumName: "status", enumValues: ["active", "inactive"] };
+      getSQLType(): string {
+        return this.enum.enumName;
+      }
+    }
+
+    const users = pgTable("users", {
+      id: serial("id").primaryKey(),
+      status: text("status").notNull(),
+    });
+
+    // Replace the column with the foreign enum column instance
+    const originalStatus = users.status as unknown as {
+      table: unknown;
+      config: Record<string, unknown>;
+    };
+    const foreignColumn = new ForeignPgEnumColumn(
+      originalStatus.table as never,
+      originalStatus.config as never,
+    );
+    const symbolColumns = Object.getOwnPropertySymbols(users).find(
+      (sym) => sym.description === "drizzle:Columns",
+    );
+    expect(symbolColumns).toBeDefined();
+    (users as unknown as Record<symbol, Record<string, unknown>>)[symbolColumns!].status =
+      foreignColumn;
+
+    expect(foreignColumn instanceof PgEnumColumn).toBe(false);
+
+    const generator = new PgGenerator({ schema: { users } });
+    const schema = generator.toIntermediateSchema();
+
+    expect(schema.enums).toHaveLength(1);
+    expect(schema.enums[0].name).toBe("status");
+    expect(schema.enums[0].values).toEqual(["active", "inactive"]);
+  });
+
+  it("should merge enum comments from pre-extracted comments", async () => {
+    const { pgEnum } = await import("drizzle-orm/pg-core");
+
+    const statusEnum = pgEnum("status", ["active", "inactive", "pending"]);
+
+    const users = pgTable("users", {
+      id: serial("id").primaryKey(),
+      status: statusEnum("status").notNull(),
+    });
+
+    const comments: SchemaComments = {
+      tables: {},
+      enums: {
+        status: {
+          comment: "Account status",
+          values: {
+            active: { comment: "Account is active" },
+            inactive: { comment: "Account is disabled" },
+          },
+        },
+      },
+    };
+
+    const generator = new PgGenerator({ schema: { users, statusEnum }, comments });
+    const schema = generator.toIntermediateSchema();
+
+    expect(schema.enums).toHaveLength(1);
+    expect(schema.enums[0].comment).toBe("Account status");
+    expect(schema.enums[0].valueComments).toEqual({
+      active: "Account is active",
+      inactive: "Account is disabled",
+    });
+  });
+
+  it("should leave enum comments undefined when no enum comments are provided", async () => {
+    const { pgEnum } = await import("drizzle-orm/pg-core");
+
+    const statusEnum = pgEnum("status", ["active", "inactive"]);
+
+    const users = pgTable("users", {
+      id: serial("id").primaryKey(),
+      status: statusEnum("status").notNull(),
+    });
+
+    // Pre-extracted comments without the enums field (backward compatibility)
+    const comments: SchemaComments = { tables: {} };
+
+    const generator = new PgGenerator({ schema: { users, statusEnum }, comments });
+    const schema = generator.toIntermediateSchema();
+
+    expect(schema.enums[0].comment).toBeUndefined();
+    expect(schema.enums[0].valueComments).toBeUndefined();
+  });
+
+  it("should extract enum comments from source file", async () => {
+    const { pgEnum } = await import("drizzle-orm/pg-core");
+    const ENUM_TEST_DIR = join(import.meta.dirname, "__test_fixtures_enum__");
+    mkdirSync(ENUM_TEST_DIR, { recursive: true });
+
+    try {
+      const filePath = join(ENUM_TEST_DIR, "schema.ts");
+      writeFileSync(
+        filePath,
+        `
+import { pgTable, pgEnum, serial } from "drizzle-orm/pg-core";
+
+/** Bike body type */
+export const bikeBodyTypeEnum = pgEnum("bike_body_type", [
+  /** No fairing */
+  "naked",
+  "quadricycle",
+]);
+
+/** Bikes */
+export const bikes = pgTable("bikes", {
+  id: serial("id").primaryKey(),
+  /** Body type */
+  bodyType: bikeBodyTypeEnum("body_type").notNull(),
+});
+`,
+      );
+
+      const bikeBodyTypeEnum = pgEnum("bike_body_type", ["naked", "quadricycle"]);
+      const bikes = pgTable("bikes", {
+        id: serial("id").primaryKey(),
+        bodyType: bikeBodyTypeEnum("body_type").notNull(),
+      });
+
+      const generator = new PgGenerator({
+        schema: { bikes, bikeBodyTypeEnum },
+        source: filePath,
+      });
+      const schema = generator.toIntermediateSchema();
+
+      expect(schema.enums).toHaveLength(1);
+      expect(schema.enums[0].comment).toBe("Bike body type");
+      expect(schema.enums[0].valueComments).toEqual({ naked: "No fairing" });
+
+      const dbml = pgGenerate({ schema: { bikes, bikeBodyTypeEnum }, source: filePath });
+      expect(dbml).toContain("// Bike body type");
+      expect(dbml).toContain('Enum "bike_body_type" {');
+      expect(dbml).toContain("naked [note: 'No fairing']");
+      expect(dbml).toContain("quadricycle");
+    } finally {
+      rmSync(ENUM_TEST_DIR, { recursive: true, force: true });
+    }
   });
 });
 

--- a/src/generator/pg.ts
+++ b/src/generator/pg.ts
@@ -1,7 +1,15 @@
-import { type AnyColumn, getTableColumns } from "drizzle-orm";
-import { PgEnumColumn } from "drizzle-orm/pg-core";
+import { type AnyColumn, getTableColumns, is } from "drizzle-orm";
+import { PgEnumColumn, PgEnumObjectColumn } from "drizzle-orm/pg-core";
 import { BaseGenerator, writeDbmlFile, type DialectConfig } from "./common";
 import type { GenerateOptions, EnumDefinition } from "../types";
+
+/**
+ * Runtime shape of a pgEnum instance attached to an enum column
+ */
+interface PgEnumLike {
+  enumName: string;
+  enumValues: string[];
+}
 
 /**
  * PostgreSQL-specific DBML generator
@@ -30,12 +38,13 @@ export class PgGenerator<
       const columns = getTableColumns(table);
 
       for (const column of Object.values(columns)) {
-        if (column instanceof PgEnumColumn) {
-          const enumObj = (
-            column as unknown as { enum: { enumName: string; enumValues: string[] } }
-          ).enum;
+        // Use drizzle's is() (entityKind brand check) instead of instanceof.
+        // The schema may be loaded from a different drizzle-orm module instance
+        // than the one this generator imports, in which case instanceof is always false.
+        if (is(column, PgEnumColumn) || is(column, PgEnumObjectColumn)) {
+          const enumObj = (column as unknown as { enum: PgEnumLike | undefined }).enum;
           if (enumObj && !enums.has(enumObj.enumName)) {
-            enums.set(enumObj.enumName, enumObj.enumValues);
+            enums.set(enumObj.enumName, [...enumObj.enumValues]);
           }
         }
       }
@@ -48,7 +57,8 @@ export class PgGenerator<
    * Collect enum definitions for intermediate schema
    *
    * Overrides the base implementation to extract PostgreSQL enum types
-   * from enum columns in the schema.
+   * from enum columns in the schema, merging JSDoc comments extracted
+   * from the source (enum-level and per-value) when available.
    *
    * @returns Array of enum definitions
    */
@@ -57,9 +67,20 @@ export class PgGenerator<
     const enumDefinitions: EnumDefinition[] = [];
 
     for (const [name, values] of enums) {
+      const enumComment = this.comments?.enums?.[name];
+      const valueComments: Record<string, string> = {};
+      for (const value of values) {
+        const valueComment = enumComment?.values[value]?.comment;
+        if (valueComment) {
+          valueComments[value] = valueComment;
+        }
+      }
+
       enumDefinitions.push({
         name,
         values,
+        comment: enumComment?.comment,
+        valueComments: Object.keys(valueComments).length > 0 ? valueComments : undefined,
       });
     }
 

--- a/src/generator/pg.ts
+++ b/src/generator/pg.ts
@@ -44,7 +44,7 @@ export class PgGenerator<
         if (is(column, PgEnumColumn) || is(column, PgEnumObjectColumn)) {
           const enumObj = (column as unknown as { enum: PgEnumLike | undefined }).enum;
           if (enumObj && !enums.has(enumObj.enumName)) {
-            enums.set(enumObj.enumName, [...enumObj.enumValues]);
+            enums.set(enumObj.enumName, enumObj.enumValues);
           }
         }
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,13 @@
 
 // Comment extraction from source files
 export { extractComments } from "./parser/comments";
-export type { SchemaComments, TableComment, ColumnComment } from "./parser/comments";
+export type {
+  SchemaComments,
+  TableComment,
+  ColumnComment,
+  EnumComment,
+  EnumValueComment,
+} from "./parser/comments";
 
 // DBML generators
 export { pgGenerate, PgGenerator } from "./generator/pg";

--- a/src/parser/comments.test.ts
+++ b/src/parser/comments.test.ts
@@ -449,4 +449,184 @@ export const users = pgTable("users", {
       expect(comments.tables.users.comment).toBe("");
     });
   });
+  describe("Directory input", () => {
+    it("should skip node_modules and hidden directories", () => {
+      const dir = join(TEST_DIR, "dir-input");
+      mkdirSync(join(dir, "node_modules", "some-pkg"), { recursive: true });
+      mkdirSync(join(dir, ".hidden"), { recursive: true });
+      mkdirSync(join(dir, "nested"), { recursive: true });
+
+      writeFileSync(
+        join(dir, "nested", "users.ts"),
+        `
+import { pgTable, serial } from "drizzle-orm/pg-core";
+/** Users */
+export const users = pgTable("users", { id: serial("id").primaryKey() });
+`,
+      );
+      writeFileSync(
+        join(dir, "node_modules", "some-pkg", "schema.ts"),
+        `
+import { pgTable, serial } from "drizzle-orm/pg-core";
+/** From node_modules */
+export const vendored = pgTable("vendored", { id: serial("id").primaryKey() });
+`,
+      );
+      writeFileSync(
+        join(dir, ".hidden", "schema.ts"),
+        `
+import { pgTable, serial } from "drizzle-orm/pg-core";
+/** Hidden */
+export const hidden = pgTable("hidden", { id: serial("id").primaryKey() });
+`,
+      );
+
+      const comments = extractComments(dir);
+
+      expect(comments.tables.users.comment).toBe("Users");
+      expect(comments.tables.vendored).toBeUndefined();
+      expect(comments.tables.hidden).toBeUndefined();
+    });
+  });
+
+  describe("Enum comments (pgEnum)", () => {
+    it("should extract enum comment and value comments from array form", () => {
+      const schemaCode = `
+import { pgEnum } from "drizzle-orm/pg-core";
+
+/** Body type of a bike */
+export const bikeBodyTypeEnum = pgEnum("bike_body_type", [
+  /** No fairing */
+  "naked",
+  /** Dual purpose on/off-road */
+  "onOff",
+  "quadricycle",
+]);
+`;
+      const filePath = join(TEST_DIR, "enum-array-form.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.enums).toBeDefined();
+      expect(comments.enums?.bike_body_type).toBeDefined();
+      expect(comments.enums?.bike_body_type.comment).toBe("Body type of a bike");
+      expect(comments.enums?.bike_body_type.values.naked.comment).toBe("No fairing");
+      expect(comments.enums?.bike_body_type.values.onOff.comment).toBe("Dual purpose on/off-road");
+      expect(comments.enums?.bike_body_type.values.quadricycle).toBeUndefined();
+      // Enums must not be registered as tables
+      expect(comments.tables.bike_body_type).toBeUndefined();
+    });
+
+    it("should extract value comments from object form keyed by database value", () => {
+      const schemaCode = `
+import { pgEnum } from "drizzle-orm/pg-core";
+
+/** Order status */
+export const orderStatusEnum = pgEnum("order_status", {
+  /** Order was created */
+  Created: "created",
+  /** Order was shipped */
+  Shipped: "shipped",
+});
+`;
+      const filePath = join(TEST_DIR, "enum-object-form.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.enums?.order_status.comment).toBe("Order status");
+      expect(comments.enums?.order_status.values.created.comment).toBe("Order was created");
+      expect(comments.enums?.order_status.values.shipped.comment).toBe("Order was shipped");
+      expect(comments.enums?.order_status.values.Created).toBeUndefined();
+    });
+
+    it("should extract comments from schema-scoped enum (pgSchema().enum())", () => {
+      const schemaCode = `
+import { pgSchema } from "drizzle-orm/pg-core";
+
+export const appSchema = pgSchema("app");
+
+/** Role in the application */
+export const roleEnum = appSchema.enum("role", [
+  /** Full access */
+  "admin",
+  "member",
+]);
+`;
+      const filePath = join(TEST_DIR, "enum-pg-schema.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.enums?.role.comment).toBe("Role in the application");
+      expect(comments.enums?.role.values.admin.comment).toBe("Full access");
+      expect(comments.enums?.role.values.member).toBeUndefined();
+    });
+
+    it("should support single-line comments on enum values", () => {
+      const schemaCode = `
+import { pgEnum } from "drizzle-orm/pg-core";
+
+// Priority level
+export const priorityEnum = pgEnum("priority", [
+  // Highest priority
+  "high",
+  "low",
+]);
+`;
+      const filePath = join(TEST_DIR, "enum-single-line.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.enums?.priority.comment).toBe("Priority level");
+      expect(comments.enums?.priority.values.high.comment).toBe("Highest priority");
+    });
+
+    it("should register enum without comments with empty values", () => {
+      const schemaCode = `
+import { pgEnum } from "drizzle-orm/pg-core";
+
+export const statusEnum = pgEnum("status", ["active", "inactive"]);
+`;
+      const filePath = join(TEST_DIR, "enum-no-comments.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.enums?.status).toBeDefined();
+      expect(comments.enums?.status.comment).toBeUndefined();
+      expect(comments.enums?.status.values).toEqual({});
+    });
+
+    it("should extract enum comments alongside table comments in the same file", () => {
+      const schemaCode = `
+import { pgTable, pgEnum, serial } from "drizzle-orm/pg-core";
+
+/** Bike body type */
+export const bikeBodyTypeEnum = pgEnum("bike_body_type", [
+  /** No fairing */
+  "naked",
+]);
+
+/** Bikes table */
+export const bikes = pgTable("bikes", {
+  /** Primary key */
+  id: serial("id").primaryKey(),
+  /** Body type of the bike */
+  bodyType: bikeBodyTypeEnum("body_type").notNull(),
+});
+`;
+      const filePath = join(TEST_DIR, "enum-with-table.ts");
+      writeFileSync(filePath, schemaCode);
+
+      const comments = extractComments(filePath);
+
+      expect(comments.tables.bikes.comment).toBe("Bikes table");
+      expect(comments.tables.bikes.columns.body_type.comment).toBe("Body type of the bike");
+      expect(comments.enums?.bike_body_type.comment).toBe("Bike body type");
+      expect(comments.enums?.bike_body_type.values.naked.comment).toBe("No fairing");
+    });
+  });
 });

--- a/src/parser/comments.ts
+++ b/src/parser/comments.ts
@@ -18,15 +18,43 @@ export interface TableComment {
 }
 
 /**
+ * Comment for a single enum value
+ */
+export interface EnumValueComment {
+  comment: string;
+}
+
+/**
+ * Comments for a single enum (PostgreSQL pgEnum)
+ */
+export interface EnumComment {
+  comment?: string;
+  values: Record<string, EnumValueComment>;
+}
+
+/**
  * All extracted comments from a schema file
  */
 export interface SchemaComments {
   tables: Record<string, TableComment>;
+  /**
+   * Comments for PostgreSQL enums, keyed by enum name.
+   * Optional for backward compatibility with pre-extracted comments.
+   */
+  enums?: Record<string, EnumComment>;
 }
 
 /**
  * Get all TypeScript files from a path (file or directory)
  */
+/**
+ * Directories that never contain user schema files and must not be scanned
+ * (dependencies and hidden directories such as .git)
+ */
+function isIgnoredDirectory(name: string): boolean {
+  return name === "node_modules" || name.startsWith(".");
+}
+
 function getTypeScriptFiles(sourcePath: string): string[] {
   const stat = statSync(sourcePath);
 
@@ -41,6 +69,9 @@ function getTypeScriptFiles(sourcePath: string): string[] {
     for (const entry of entries) {
       const fullPath = join(sourcePath, entry.name);
       if (entry.isDirectory()) {
+        if (isIgnoredDirectory(entry.name)) {
+          continue;
+        }
         files.push(...getTypeScriptFiles(fullPath));
       } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
         files.push(fullPath);
@@ -59,12 +90,13 @@ function getTypeScriptFiles(sourcePath: string): string[] {
  * Parses TypeScript source files and extracts:
  * - JSDoc comments on table definitions (e.g., pgTable, mysqlTable, sqliteTable)
  * - JSDoc comments on column definitions within tables
+ * - JSDoc comments on enum definitions (pgEnum) and their values
  *
  * @param sourcePath - Path to the TypeScript schema file or directory
- * @returns Extracted comments organized by table and column
+ * @returns Extracted comments organized by table, column, and enum
  */
 export function extractComments(sourcePath: string): SchemaComments {
-  const comments: SchemaComments = { tables: {} };
+  const comments: SchemaComments = { tables: {}, enums: {} };
   const files = getTypeScriptFiles(sourcePath);
 
   for (const filePath of files) {
@@ -100,6 +132,13 @@ function visitNode(node: ts.Node, sourceFile: ts.SourceFile, comments: SchemaCom
         );
         if (tableInfo) {
           comments.tables[tableInfo.tableName] = tableInfo.tableComment;
+          continue;
+        }
+
+        const enumInfo = parseEnumDefinition(declaration.initializer, sourceFile, jsDocComment);
+        if (enumInfo) {
+          comments.enums ??= {};
+          comments.enums[enumInfo.enumName] = enumInfo.enumComment;
         }
       }
     }
@@ -158,6 +197,70 @@ function parseTableDefinition(
 }
 
 /**
+ * Parse an enum definition call expression
+ *
+ * Supports both the array form and the object form of pgEnum:
+ * - pgEnum("status", ["active", "inactive"])
+ * - pgEnum("status", { Active: "active", Inactive: "inactive" })
+ * - mySchema.enum("status", [...]) (pgSchema().enum())
+ *
+ * Value comments are keyed by the database value (string literal), not the
+ * TypeScript object key.
+ */
+function parseEnumDefinition(
+  callExpr: ts.CallExpression,
+  sourceFile: ts.SourceFile,
+  enumJsDoc: string | undefined,
+): { enumName: string; enumComment: EnumComment } | undefined {
+  const funcName = getCallExpressionName(callExpr);
+
+  if (!isEnumDefinitionFunction(funcName)) {
+    return undefined;
+  }
+
+  // Get enum name from first argument
+  const enumNameArg = callExpr.arguments[0];
+  if (!enumNameArg || !ts.isStringLiteral(enumNameArg)) {
+    return undefined;
+  }
+  const enumName = enumNameArg.text;
+
+  // Get enum values from second argument
+  const valuesArg = callExpr.arguments[1];
+  const valueComments: Record<string, EnumValueComment> = {};
+
+  if (valuesArg && ts.isArrayLiteralExpression(valuesArg)) {
+    for (const element of valuesArg.elements) {
+      if (ts.isStringLiteralLike(element)) {
+        const valueJsDoc = getJsDocComment(element, sourceFile);
+        if (valueJsDoc) {
+          valueComments[element.text] = { comment: valueJsDoc };
+        }
+      }
+    }
+  } else if (valuesArg && ts.isObjectLiteralExpression(valuesArg)) {
+    for (const property of valuesArg.properties) {
+      if (ts.isPropertyAssignment(property) && ts.isStringLiteralLike(property.initializer)) {
+        const valueJsDoc = getJsDocComment(property, sourceFile);
+        if (valueJsDoc) {
+          valueComments[property.initializer.text] = { comment: valueJsDoc };
+        }
+      }
+    }
+  } else {
+    return undefined;
+  }
+
+  return {
+    enumName,
+    enumComment: {
+      comment: enumJsDoc,
+      values: valueComments,
+    },
+  };
+}
+
+/**
  * Get the function name from a call expression
  */
 function getCallExpressionName(callExpr: ts.CallExpression): string | undefined {
@@ -176,6 +279,16 @@ function getCallExpressionName(callExpr: ts.CallExpression): string | undefined 
 function isTableDefinitionFunction(funcName: string | undefined): boolean {
   if (!funcName) return false;
   return ["pgTable", "mysqlTable", "sqliteTable"].includes(funcName);
+}
+
+/**
+ * Check if a function name is an enum definition function
+ *
+ * `enum` covers the schema-scoped form: pgSchema("name").enum(...)
+ */
+function isEnumDefinitionFunction(funcName: string | undefined): boolean {
+  if (!funcName) return false;
+  return ["pgEnum", "enum"].includes(funcName);
 }
 
 /**

--- a/src/parser/comments.ts
+++ b/src/parser/comments.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 import { readFileSync, statSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import { isIgnoredDirectory } from "./files";
 
 /**
  * Comments for a single column
@@ -47,14 +48,6 @@ export interface SchemaComments {
 /**
  * Get all TypeScript files from a path (file or directory)
  */
-/**
- * Directories that never contain user schema files and must not be scanned
- * (dependencies and hidden directories such as .git)
- */
-function isIgnoredDirectory(name: string): boolean {
-  return name === "node_modules" || name.startsWith(".");
-}
-
 function getTypeScriptFiles(sourcePath: string): string[] {
   const stat = statSync(sourcePath);
 
@@ -96,7 +89,7 @@ function getTypeScriptFiles(sourcePath: string): string[] {
  * @returns Extracted comments organized by table, column, and enum
  */
 export function extractComments(sourcePath: string): SchemaComments {
-  const comments: SchemaComments = { tables: {}, enums: {} };
+  const comments: Required<SchemaComments> = { tables: {}, enums: {} };
   const files = getTypeScriptFiles(sourcePath);
 
   for (const filePath of files) {
@@ -113,7 +106,11 @@ export function extractComments(sourcePath: string): SchemaComments {
 /**
  * Recursively visit AST nodes to find table and column definitions
  */
-function visitNode(node: ts.Node, sourceFile: ts.SourceFile, comments: SchemaComments): void {
+function visitNode(
+  node: ts.Node,
+  sourceFile: ts.SourceFile,
+  comments: Required<SchemaComments>,
+): void {
   // Look for variable declarations that define tables
   if (ts.isVariableStatement(node)) {
     const jsDocComment = getJsDocComment(node, sourceFile);
@@ -137,7 +134,6 @@ function visitNode(node: ts.Node, sourceFile: ts.SourceFile, comments: SchemaCom
 
         const enumInfo = parseEnumDefinition(declaration.initializer, sourceFile, jsDocComment);
         if (enumInfo) {
-          comments.enums ??= {};
           comments.enums[enumInfo.enumName] = enumInfo.enumComment;
         }
       }

--- a/src/parser/files.ts
+++ b/src/parser/files.ts
@@ -1,0 +1,9 @@
+/**
+ * Check whether a directory must be skipped when scanning for schema files
+ *
+ * Dependencies (node_modules) and hidden directories (e.g. .git) never contain
+ * user schema files, and importing files from them can fail.
+ */
+export function isIgnoredDirectory(name: string): boolean {
+  return name === "node_modules" || name.startsWith(".");
+}

--- a/src/parser/relations.test.ts
+++ b/src/parser/relations.test.ts
@@ -14,6 +14,29 @@ describe("extractRelations", () => {
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
+  it("should skip node_modules and hidden directories when given a directory", () => {
+    const dir = join(TEST_DIR, "dir-input");
+    mkdirSync(join(dir, "node_modules", "some-pkg"), { recursive: true });
+    mkdirSync(join(dir, ".hidden"), { recursive: true });
+
+    const relationCode = (source: string, target: string) => `
+import { relations } from "drizzle-orm";
+export const ${source}Relations = relations(${source}, ({ one }) => ({
+  target: one(${target}, { fields: [${source}.targetId], references: [${target}.id] }),
+}));
+`;
+    writeFileSync(join(dir, "schema.ts"), relationCode("posts", "users"));
+    writeFileSync(
+      join(dir, "node_modules", "some-pkg", "schema.ts"),
+      relationCode("vendored", "users"),
+    );
+    writeFileSync(join(dir, ".hidden", "schema.ts"), relationCode("hidden", "users"));
+
+    const result = extractRelations(dir);
+
+    expect(result.relations.map((r) => r.sourceTable)).toEqual(["posts"]);
+  });
+
   it("should extract one() relation with fields and references", () => {
     const schemaCode = `
 import { pgTable, serial, text, integer } from "drizzle-orm/pg-core";

--- a/src/parser/relations.ts
+++ b/src/parser/relations.ts
@@ -28,6 +28,14 @@ export interface SchemaRelations {
 /**
  * Get all TypeScript files from a path (file or directory)
  */
+/**
+ * Directories that never contain user schema files and must not be scanned
+ * (dependencies and hidden directories such as .git)
+ */
+function isIgnoredDirectory(name: string): boolean {
+  return name === "node_modules" || name.startsWith(".");
+}
+
 function getTypeScriptFiles(sourcePath: string): string[] {
   const stat = statSync(sourcePath);
 
@@ -42,6 +50,9 @@ function getTypeScriptFiles(sourcePath: string): string[] {
     for (const entry of entries) {
       const fullPath = join(sourcePath, entry.name);
       if (entry.isDirectory()) {
+        if (isIgnoredDirectory(entry.name)) {
+          continue;
+        }
         files.push(...getTypeScriptFiles(fullPath));
       } else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".test.ts")) {
         files.push(fullPath);

--- a/src/parser/relations.ts
+++ b/src/parser/relations.ts
@@ -1,6 +1,7 @@
 import * as ts from "typescript";
 import { readFileSync, statSync, readdirSync } from "node:fs";
 import { join } from "node:path";
+import { isIgnoredDirectory } from "./files";
 
 /**
  * Parsed relation from relations() definition
@@ -28,14 +29,6 @@ export interface SchemaRelations {
 /**
  * Get all TypeScript files from a path (file or directory)
  */
-/**
- * Directories that never contain user schema files and must not be scanned
- * (dependencies and hidden directories such as .git)
- */
-function isIgnoredDirectory(name: string): boolean {
-  return name === "node_modules" || name.startsWith(".");
-}
-
 function getTypeScriptFiles(sourcePath: string): string[] {
   const stat = statSync(sourcePath);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,6 +166,10 @@ export interface EnumDefinition {
   schema?: string;
   /** Enum values */
   values: string[];
+  /** JSDoc comment or description for this enum */
+  comment?: string;
+  /** JSDoc comments for individual enum values, keyed by value */
+  valueComments?: Record<string, string>;
 }
 
 /**


### PR DESCRIPTION
## 概要

PostgreSQL の `pgEnum` まわりの 3 つのバグ (#158) と、調査中に見つかった関連バグを修正します。

Closes #158

1. **重複した `drizzle-orm` で enum が検出されない**: `src/generator/pg.ts` が `column instanceof PgEnumColumn` で判定していたため、CLI 側と対象プロジェクト側で別コピーの `drizzle-orm` が読み込まれるとクラスの同一性が崩れ、enum が一切出力されなかった
2. **複数ファイル Markdown 出力に enum が含まれない**: `writeMarkdownMultipleFiles` がテーブルしか書き出しておらず、`--single-file` のときだけ `# Enums` が出ていた
3. **enum の JSDoc コメントが抽出されない**: parser が `pgTable` 系しか見ておらず、`pgEnum` 本体および各値のコメントが DBML / Markdown に反映されなかった

## 変更内容

### Bug 1: enum 検出

- `instanceof` を drizzle の `is()` (`entityKind` ブランド判定) に置き換え、別モジュールインスタンスでも検出できるようにした
- object 形式 `pgEnum("x", { A: "a" })` が生成する `PgEnumObjectColumn` も検出対象に追加 (従来は array 形式しか拾えていなかった)

### Bug 2: 複数ファイル Markdown

- enum がある場合に `enums.md` を出力し、`README.md` の Tables index の下に Enums index (`Name | Values | Comment`、`./enums.md#<name>` へのリンク) を追加
- `--force` なしの上書きチェックでも `enums.md` を考慮するようにした

### Bug 3: enum コメント

- `src/parser/comments.ts` に `pgEnum(...)` / `pgSchema("x").enum(...)` の解析を追加。enum 本体の JSDoc と、各値の leading JSDoc (`//` 単行コメントも可) を array 形式・object 形式 (DB 値をキーにする) の両方で抽出
- `SchemaComments` に `enums?`、`EnumDefinition` に `comment?` / `valueComments?` を追加 (事前抽出済みコメントとの後方互換のため optional)。`EnumComment` / `EnumValueComment` 型を公開 API から export
- Markdown: enum 見出し直下に説明文を出し、値に 1 つでもコメントがあれば `| Value | Comment |` の 2 列テーブルにする (なければ従来どおり 1 列)
- DBML: 値は `value [note: '...']`、enum 本体は `Enum` ブロック直上の `//` 行コメントとして出力。DBML 仕様上 `Enum {}` 内に `Note:` は書けないことを `@dbml/core` のパーサで確認した上での判断

### 関連バグ (調査中に発見)

- **DBML 経路のディレクトリ入力**: `generateDbmlOutput` が `source` に先頭ファイル 1 つだけを渡していたため、ディレクトリ指定時に他ファイルのテーブル / カラム / enum コメントが落ちていた。Markdown 経路と同じくディレクトリを渡すよう統一
- **`node_modules` / 隠しディレクトリの走査**: CLI の `findSchemaFiles` と parser の `getTypeScriptFiles` がディレクトリ配下を無条件に再帰していたため、`node_modules` を含むディレクトリを渡すと依存パッケージ内のファイルを import しようとして失敗していた。`node_modules` と `.` で始まるディレクトリはスキップする
- **DBML enum 値のクォート**: `on-off` や `in progress` のような識別子でない値をそのまま出力しており、DBML として不正だった。識別子 (文字・数字・`_`) 以外を含む値は `"..."` で囲む

### その他

- `examples/pg/v0/schema.ts` / `examples/pg/v1/schema.ts` にコメント付きの `order_status` enum を追加し、`pnpm generate:examples` で `schema.dbml` と `markdown/` (`enums.md` 新規) を再生成 (CI の v0/v1 DBML 同一チェックのため両方に追加)
- README.md / README.ja.md に PostgreSQL enum 対応、`enums.md`、enum コメントの例を追記

## テスト

- [x] `src/parser/comments.test.ts`: array / object / `pgSchema().enum` 形式、単行コメント、テーブルとの同居、`node_modules` スキップ
- [x] `src/parser/relations.test.ts`: `node_modules` スキップ
- [x] `src/generator/pg.test.ts`: 別モジュールインスタンスを模倣したクラス (`entityKind` のみ一致) の検出、object 形式、コメントのマージ、ソースファイルからの end-to-end。旧コード (`instanceof`) では失敗することを確認済み
- [x] `src/formatter/dbml.test.ts` / `markdown.test.ts`: コメント出力、`includeComments: false`、値のクォート、Enums index
- [x] integration: `node_modules/drizzle-orm` を別コピーした一時プロジェクトで DBML / Markdown を生成 (issue の再現条件)、プロジェクトルート指定で `node_modules` を無視すること、`enums.md` の有無
- [x] `pnpm format && pnpm lint && pnpm typecheck && pnpm test:run` (224 件) がすべて成功
- [x] `pnpm build && pnpm test:integration` (62 件) がすべて成功
- [x] 生成した `examples/pg/v1/schema.dbml` を `@dbml/core` でパースし、enum の note を含めて正常に読めることを確認

## 補足

- enum のコメントは enum を定義しているファイルが `source` に含まれる場合のみ抽出されます (issue の指摘どおり)。README にはディレクトリ指定を推奨する旨を記載しました
- #160 が先にマージされたため `main` を取り込み済みです。`src/parser/comments.ts` の `visitNode` シグネチャのみ競合しましたが、#160 が追加した `CasingScope` 引数と本 PR の `Required<SchemaComments>` の両方を残す形で解消しました
