### PR TITLE
feat: upgrade to TypeScript 7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,9 +60,10 @@ pnpm format && pnpm lint && pnpm typecheck && pnpm test:run
 
 ## Dependencies
 
-- `typescript`: AST parsing
+- `@typescript/typescript6`: AST parsing (JavaScript Compiler API; TypeScript 7 dropped it from the `typescript` package root)
 - `commander`: CLI framework
 - `drizzle-orm`: Drizzle ORM v1 beta
+- `typescript` (dev only): type checking / declaration emit with the TypeScript 7 native compiler
 
 ## Type Guidelines
 

--- a/package.json
+++ b/package.json
@@ -52,16 +52,17 @@
     "prepublishOnly": "pnpm run format && pnpm run lint && pnpm run typecheck && pnpm run test:run && pnpm run build"
   },
   "dependencies": {
+    "@typescript/typescript6": "^6.0.2",
     "commander": "^15.0.0",
     "drizzle-orm": "1.0.0-rc.4",
-    "tsx": "^4.21.0",
-    "typescript": "^6.0.2"
+    "tsx": "^4.21.0"
   },
   "devDependencies": {
     "@types/node": "^24.10.7",
     "@vitest/coverage-v8": "^4.0.18",
     "oxfmt": "^0.56.0",
     "oxlint": "^1.42.0",
+    "typescript": "^7.0.2",
     "vite": "^8.0.0",
     "vite-plugin-dts": "^5.0.0",
     "vitest": "^4.0.18"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@typescript/typescript6':
+        specifier: ^6.0.2
+        version: 6.0.2
       commander:
         specifier: ^15.0.0
         version: 15.0.0
@@ -17,9 +20,6 @@ importers:
       tsx:
         specifier: ^4.21.0
         version: 4.22.4
-      typescript:
-        specifier: ^6.0.2
-        version: 6.0.3
     devDependencies:
       '@types/node':
         specifier: ^24.10.7
@@ -33,12 +33,15 @@ importers:
       oxlint:
         specifier: ^1.42.0
         version: 1.71.0
+      typescript:
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
         specifier: ^8.0.0
         version: 8.1.0(@types/node@24.13.2)(esbuild@0.28.0)(tsx@4.22.4)
       vite-plugin-dts:
         specifier: ^5.0.0
-        version: 5.0.3(@microsoft/api-extractor@7.55.2(@types/node@24.13.2))(esbuild@0.28.0)(rolldown@1.1.3)(rollup@4.56.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.0)(tsx@4.22.4))
+        version: 5.0.3(@microsoft/api-extractor@7.55.2(@types/node@24.13.2))(esbuild@0.28.0)(rolldown@1.1.3)(rollup@4.56.0)(typescript@7.0.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.0)(tsx@4.22.4))
       vitest:
         specifier: ^4.0.18
         version: 4.1.9(@types/node@24.13.2)(@vitest/coverage-v8@4.1.9)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.0)(tsx@4.22.4))
@@ -861,6 +864,130 @@ packages:
   '@types/readable-stream@4.0.23':
     resolution: {integrity: sha512-wwXrtQvbMHxCbBgjHaMGEmImFTQxxpfMOR/ZoQnXxB1woqkUbdLGFDgauo00Py9IudiaqSeiBiulSV9i6XIPig==}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/typescript6@6.0.2':
+    resolution: {integrity: sha512-mbCddXd+jm7hfx7w2YU64/Av4/NqqeG3GoRZgxPcgoTxYjhrcfJRw9ULch71SS4G+Q3bOXFhRvPqjguN0Hyp5w==}
+    hasBin: true
+
   '@typespec/ts-http-runtime@0.3.6':
     resolution: {integrity: sha512-jIXhD0eWQ1JA6ln/5Dltyx22UxWNrw0hZmhy2rlv6m6KgF7kplHx3g0fzi09lNmTJQRR91OlemYp3xFnvDK9og==}
     engines: {node: '>=20.0.0'}
@@ -1678,6 +1805,11 @@ packages:
   typescript@6.0.3:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
+    hasBin: true
+
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   ufo@1.6.4:
@@ -2519,6 +2651,70 @@ snapshots:
       '@types/node': 24.13.2
     optional: true
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript6@6.0.2':
+    dependencies:
+      '@typescript/old': typescript@6.0.3
+
   '@typespec/ts-http-runtime@0.3.6':
     dependencies:
       http-proxy-agent: 7.0.2
@@ -3329,6 +3525,29 @@ snapshots:
 
   typescript@6.0.3: {}
 
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
+
   ufo@1.6.4: {}
 
   undici-types@7.18.2: {}
@@ -3336,7 +3555,7 @@ snapshots:
   universalify@2.0.1:
     optional: true
 
-  unplugin-dts@1.0.3(@microsoft/api-extractor@7.55.2(@types/node@24.13.2))(esbuild@0.28.0)(rolldown@1.1.3)(rollup@4.56.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.0)(tsx@4.22.4)):
+  unplugin-dts@1.0.3(@microsoft/api-extractor@7.55.2(@types/node@24.13.2))(esbuild@0.28.0)(rolldown@1.1.3)(rollup@4.56.0)(typescript@7.0.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.0)(tsx@4.22.4)):
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.56.0)
       '@volar/typescript': 2.4.28
@@ -3345,7 +3564,7 @@ snapshots:
       kolorist: 1.8.0
       local-pkg: 1.2.1
       magic-string: 0.30.21
-      typescript: 6.0.3
+      typescript: 7.0.2
       unplugin: 2.3.11
     optionalDependencies:
       '@microsoft/api-extractor': 7.55.2(@types/node@24.13.2)
@@ -3368,9 +3587,9 @@ snapshots:
       punycode: 2.3.1
     optional: true
 
-  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.55.2(@types/node@24.13.2))(esbuild@0.28.0)(rolldown@1.1.3)(rollup@4.56.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.0)(tsx@4.22.4)):
+  vite-plugin-dts@5.0.3(@microsoft/api-extractor@7.55.2(@types/node@24.13.2))(esbuild@0.28.0)(rolldown@1.1.3)(rollup@4.56.0)(typescript@7.0.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.0)(tsx@4.22.4)):
     dependencies:
-      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.55.2(@types/node@24.13.2))(esbuild@0.28.0)(rolldown@1.1.3)(rollup@4.56.0)(typescript@6.0.3)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.0)(tsx@4.22.4))
+      unplugin-dts: 1.0.3(@microsoft/api-extractor@7.55.2(@types/node@24.13.2))(esbuild@0.28.0)(rolldown@1.1.3)(rollup@4.56.0)(typescript@7.0.2)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.0)(tsx@4.22.4))
     optionalDependencies:
       '@microsoft/api-extractor': 7.55.2(@types/node@24.13.2)
       rollup: 4.56.0

--- a/src/parser/comments.ts
+++ b/src/parser/comments.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import * as ts from "@typescript/typescript6";
 import { getCasingFn, type Casing } from "drizzle-orm/casing";
 import { readFileSync, statSync, readdirSync } from "node:fs";
 import { join } from "node:path";

--- a/src/parser/relations.ts
+++ b/src/parser/relations.ts
@@ -1,4 +1,4 @@
-import * as ts from "typescript";
+import * as ts from "@typescript/typescript6";
 import { readFileSync, statSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { isIgnoredDirectory } from "./files";

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
     sourcemap: true,
     rollupOptions: {
       external: [
-        "typescript",
+        "@typescript/typescript6",
         "commander",
         "drizzle-orm",
         "tsx",


### PR DESCRIPTION
## 背景

Dependabot が TypeScript を 6.0.3 → 7.0.2 に上げると CI の `tsc --noEmit` が 60 件以上の型エラーで落ちる（#162 で発覚）。原因は TypeScript 7 のパッケージ構成変更で、**`typescript` パッケージのルートから JavaScript Compiler API が消えた**こと。

```json
// typescript@7.0.2/package.json
"exports": {
  ".": "./lib/version.cjs",          // ← バージョン情報のみ
  "./unstable/sync": "./dist/api/sync/api.js",
  "./unstable/ast": "./dist/ast/index.js",
  ...
}
```

本リポジトリの `src/parser/comments.ts` / `src/parser/relations.ts` は `ts.createSourceFile` / `ts.forEachChild` / `ts.getLeadingCommentRanges` / 各種 `isXxx` 型ガードを使って **純粋に構文的な**パースを行っているため、これが直撃する。

## 対応

Microsoft は TypeScript 7 の移行用に **`@typescript/typescript6`** という公式コンパニオンパッケージを出している（TypeScript 6 の JS API をそのまま re-export するシム。実体は `module.exports = require("@typescript/old")` の 1 行で、`@typescript/old` は `npm:typescript@^6`）。vite-plugin-dts も TS7 環境ではこのパッケージへ自動フォールバックする。

- `src/parser/{comments,relations}.ts`: Compiler API の import 元を `typescript` → `@typescript/typescript6` に変更（**import 1 行ずつのみ。パースロジックは無変更**）
- `package.json`: `@typescript/typescript6` を runtime dependency に追加。`typescript` は devDependencies へ移動（`dist/` から `typescript` を import する箇所が無くなったため。プラットフォーム別ネイティブバイナリを利用者にインストールさせずに済む）
- `vite.config.ts`: rollup の external を `typescript` → `@typescript/typescript6` に差し替え
- `CLAUDE.md`: 2 パッケージの役割分担を追記

## 検討した代替案（不採用）

TypeScript 7 の新 API（`typescript/unstable/sync` + `typescript/unstable/ast`）への移行も実際にスパイクを書いて検証した。**動作はする**（`API` → `updateSnapshot` → `project.program.getSourceFile()` で本物の AST が取れ、`getText()` / `getFullStart()` / `sourceFile.text` / `getLeadingCommentRanges` も classic API と互換シグネチャで使える。tsconfig が無いファイルでも inferred project にフォールバックする）。しかし以下の理由で不採用とした。

1. **パーサ本体が JS 側に存在しない。** `typescript/unstable/ast` が提供するのは型ガードと Node ファクトリのみで、テキスト → AST の変換はネイティブ Go バイナリ側にしかない。AST を得るには必ず tsgo プロセスを spawn する必要がある。
2. **起動コストの激増。** `ts.createSourceFile()` はプロセス内で数 ms。新 API は初回 `updateSnapshot` で **130ms〜900ms**（実測）。本ツールは 1 プロセスで数ファイルしか処理しない CLI なので体感が悪化する。
3. **配布リスク。** パースが `@typescript/typescript-darwin-arm64` 等のプラットフォーム別 optionalDependencies に依存し、未インストール環境では例外になる。
4. **`unstable/` 名前空間。** API が安定していない。
5. ライフサイクル管理（`API.close()` / `Snapshot.dispose()`）や ad-hoc compilerOptions を渡すための仮想 tsconfig など、既存コードに無かった状態管理が必要になる。

`@typescript/typescript6` なら import 1 行の変更で済み、AST の挙動も完全に同一。

## 検証

ローカルで CI の全ステップを実行し、すべて通過：

| ステップ | 結果 |
|---|---|
| `pnpm format:check` | ✅ 59 files |
| `pnpm lint` | ✅ |
| `pnpm typecheck`（tsc = TS7 native） | ✅ |
| `pnpm test:coverage` / `test:run` | ✅ 242 passed |
| `pnpm build` | ✅ dts 生成含む |
| `pnpm test:integration` | ✅ 62 passed |
| `pnpm generate:examples` → `git diff examples/` | ✅ 差分なし |

ビルド成果物が正しいパッケージを参照していることも確認済み：

```
dist/parser/comments.js:2:import * as t from "@typescript/typescript6";
dist/parser/relations.js:2:import * as t from "@typescript/typescript6";
```

副次的な効果として型チェックがネイティブコンパイラになり高速化した（`pnpm typecheck` 実測: **1.66s → 0.45s**）。

## #162 との関係

#162（Dependabot のグループ更新）では typescript のみ `^6.0.2` に据え置いてグリーンにしてある。本 PR がマージされれば TypeScript 7 に前進できる。両者は独立してマージ可能。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the project’s TypeScript tooling to support the latest compiler version.
  - Maintained compatibility for parser-related functionality during the tooling update.
  - No changes to exported APIs or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->