### PR TITLE
chore(release): bump version to 0.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle-docs-generator",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "A CLI tool that generates DBML files from Drizzle ORM schema definitions.",
   "keywords": [
     "cli",


### PR DESCRIPTION
## 概要
v0.7.2 以降の変更を反映してリリースする。TypeScript 7 移行 (#163) を含む feat コミットがあるため minor バージョンを上げる。

## 変更内容
- `package.json` の version を `0.7.2` → `0.8.0` に更新
- 含まれる主な変更
  - feat: TypeScript 7 へのアップグレード（#163、パース処理は `@typescript/typescript6` 経由で動作継続、公開 API・挙動に変更なし）
  - fix: v1 casing helpers で定義したテーブルの JSDoc コメント抽出（#160、issue #157 を解消）
  - fix: 重複した drizzle-orm 環境下での PostgreSQL enum 検出・複数ファイル出力対応（#161、issue #158 を解消）
  - chore(deps): 依存パッケージの各種アップデート

main へのマージ後、`.github/workflows/release.yml` が package.json の version を検知して自動で tag 作成・GitHub Release 作成・npm publish を実行する。

## テスト
- [x] `pnpm format`
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test:run`（242 件成功）
- [x] `pnpm build`
- [x] `pnpm test:integration`（62 件成功）