### PR TITLE
fix: support older drizzle-orm casing exports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,4 +114,4 @@ jobs:
           pnpm install --no-frozen-lockfile
 
       - name: Test v0 schema with compatibility Drizzle ORM
-        run: pnpm exec vitest run src/cli/cli.integration.postgresql.test.ts -t "PostgreSQL v0"
+        run: pnpm exec vitest run --config vitest.integration.config.ts src/cli/cli.integration.postgresql.test.ts -t "PostgreSQL v0"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,35 @@ jobs:
             fi
           done
           echo "✓ All v0/v1 example pairs exist and produce identical DBML output"
+
+  backward-compatibility:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        drizzle-version: ["0.45.2"]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build package
+        run: pnpm build
+
+      - name: Install compatibility Drizzle ORM
+        run: |
+          pnpm pkg set "dependencies.drizzle-orm=${{ matrix.drizzle-version }}"
+          pnpm install --no-frozen-lockfile
+
+      - name: Test v0 schema with compatibility Drizzle ORM
+        run: pnpm exec vitest run src/cli/cli.integration.postgresql.test.ts -t "PostgreSQL v0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "drizzle-docs-generator",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "A CLI tool that generates DBML files from Drizzle ORM schema definitions.",
   "keywords": [
     "cli",

--- a/src/parser/comments.ts
+++ b/src/parser/comments.ts
@@ -1,5 +1,4 @@
 import * as ts from "@typescript/typescript6";
-import { getCasingFn, type Casing } from "drizzle-orm/casing";
 import { readFileSync, statSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { isIgnoredDirectory } from "./files";
@@ -52,7 +51,37 @@ export interface SchemaComments {
  * - "snake_case" / "camelCase": Drizzle v1 casing helpers (`snakeCase`, `camelCase`)
  * - "none": other Drizzle helpers that keep property keys as-is (`pgTable`, `pgSchema`, ...)
  */
+type Casing = "snake_case" | "camelCase";
 type BindingCasing = Casing | "none";
+
+function getCasingFn(casing: Casing | undefined): (name: string) => string {
+  if (casing === "snake_case") return toSnakeCase;
+  if (casing === "camelCase") return toCamelCase;
+  return (name) => name;
+}
+
+function toSnakeCase(input: string): string {
+  return (
+    input
+      .replace(/['\u2019]/g, "")
+      .match(/[\da-z]+|[A-Z]+(?![a-z])|[A-Z][\da-z]+/g)
+      ?.map((word) => word.toLowerCase())
+      .join("_") ?? ""
+  );
+}
+
+function toCamelCase(input: string): string {
+  return (
+    input
+      .replace(/['\u2019]/g, "")
+      .match(/[\da-z]+|[A-Z]+(?![a-z])|[A-Z][\da-z]+/g)
+      ?.reduce(
+        (acc, word, i) =>
+          acc + (i === 0 ? word.toLowerCase() : `${word.charAt(0).toUpperCase()}${word.slice(1)}`),
+        "",
+      ) ?? ""
+  );
+}
 
 /**
  * Drizzle helpers that can appear in the receiver chain of a table definition,


### PR DESCRIPTION
## Summary

Fixes #165.

The v0.8.0 parser imported `getCasingFn` from `drizzle-orm/casing` at runtime. That export is not available in supported non-RC versions such as `drizzle-orm@0.45.2`, causing the CLI to fail during module loading.

This change removes the runtime dependency and keeps equivalent `snake_case` / `camelCase` conversion locally. Existing v1 casing tests cover the behavior.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm test:run`
- `pnpm build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Improved handling of naming conventions during parsing.
  - Supported `snake_case` and `camelCase` formats are now handled consistently.
  - Unrecognized or unspecified casing preserves names without transformation.
  - Parsing results now apply the selected naming convention more predictably across generated names.
  - Existing naming behavior remains unchanged when no supported casing format is selected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->