### PR TITLE
fix(dbml): valid DBML for composite foreign keys and double precision

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "tsx": "^4.21.0"
   },
   "devDependencies": {
+    "@dbml/core": "10.1.1",
     "@types/node": "^24.10.7",
     "@vitest/coverage-v8": "^4.0.18",
     "oxfmt": "^0.66.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -21,6 +21,9 @@ importers:
         specifier: ^4.21.0
         version: 4.23.13
     devDependencies:
+      '@dbml/core':
+        specifier: 10.1.1
+        version: 10.1.1
       '@types/node':
         specifier: ^24.10.7
         version: 24.13.3
@@ -139,6 +142,14 @@ packages:
 
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
+    engines: {node: '>=18'}
+
+  '@dbml/core@10.1.1':
+    resolution: {integrity: sha512-okz4w1QMLOOqFXe7gEjBMMmbyNnVJrS/MNTECoMuGzWEibUplCRYuPzpuU4TxjQ/Ag1xf+fjnmJiQXM9dAo3+Q==}
+    engines: {node: '>=16'}
+
+  '@dbml/parse@10.1.1':
+    resolution: {integrity: sha512-5diN/EBs7E3lud0vdQXcwv2CDWIB3Vhi0PyVOQv5F4UnGKjKuPnhSnSxQuxkrMSyd+nqK3ASrvuYzyVgVW3JfA==}
     engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.28.2':
@@ -1068,6 +1079,10 @@ packages:
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
+  antlr4@4.13.2:
+    resolution: {integrity: sha512-QiVbZhyy4xAZ17UPEuG3YTOt8ZaoeOR1CvEAqrEsDBsOqINslaB147i9xqljZqoyf5S+EUlGStaj+t22LT9MOg==}
+    engines: {node: '>=16'}
+
   argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
 
@@ -1534,6 +1549,9 @@ packages:
     resolution: {integrity: sha512-++gUqRDEvcnN6Zhqrr+y/CkVEHhlrR96vZn3nZZPYzMcBUyBtTKzB9NadClFIsIVSsu+3i9tfk/erqy9kAmt7Q==}
     engines: {node: '>=14'}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
 
@@ -1558,9 +1576,16 @@ packages:
   lodash@4.17.23:
     resolution: {integrity: sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   lru-cache@6.0.0:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1629,6 +1654,9 @@ packages:
       vite-plus:
         optional: true
 
+  parsimmon@1.18.1:
+    resolution: {integrity: sha512-u7p959wLfGAhJpSDJVYXoyMCXWYwHia78HhRBWqk7AIbxdmlrfdp5wX0l3xv/iTSH5HvhN9K7o26hwwpgS5Nmw==}
+
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
@@ -1650,6 +1678,10 @@ packages:
 
   pkg-types@2.3.2:
     resolution: {integrity: sha512-v0sVXzj7oPGysr543YYZLYbcJNJsKikSsp/fFzoxQ12ewY3ZZr7oCPC8y7OlmxfYB3QPvriXmuPD8KZggE1vqg==}
+
+  pluralize@8.0.0:
+    resolution: {integrity: sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==}
+    engines: {node: '>=4'}
 
   postcss@8.5.27:
     resolution: {integrity: sha512-79Iho8QeYyooJ8e9lCRyTVlyTAkS/kXBYKff6TMzS3kEWGQ8Ds5UEtXpGrSUDLUWok6QTvxeYy0GO8fopHnaSA==}
@@ -2149,6 +2181,22 @@ snapshots:
       '@babel/helper-validator-identifier': 7.29.7
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@dbml/core@10.1.1':
+    dependencies:
+      '@dbml/parse': 10.1.1
+      antlr4: 4.13.2
+      lodash: 4.18.1
+      lodash-es: 4.18.1
+      luxon: 3.7.2
+      parsimmon: 1.18.1
+      pluralize: 8.0.0
+
+  '@dbml/parse@10.1.1':
+    dependencies:
+      lodash-es: 4.18.1
+      luxon: 3.7.2
+      pathe: 2.0.3
 
   '@esbuild/aix-ppc64@0.28.2':
     optional: true
@@ -2805,6 +2853,8 @@ snapshots:
       require-from-string: 2.0.2
     optional: true
 
+  antlr4@4.13.2: {}
+
   argparse@1.0.10:
     dependencies:
       sprintf-js: 1.0.3
@@ -3144,6 +3194,8 @@ snapshots:
       pkg-types: 2.3.2
       quansync: 0.2.11
 
+  lodash-es@4.18.1: {}
+
   lodash.includes@4.3.0:
     optional: true
 
@@ -3168,10 +3220,14 @@ snapshots:
   lodash@4.17.23:
     optional: true
 
+  lodash@4.18.1: {}
+
   lru-cache@6.0.0:
     dependencies:
       yallist: 4.0.0
     optional: true
+
+  luxon@3.7.2: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -3274,6 +3330,8 @@ snapshots:
       '@oxlint/binding-win32-ia32-msvc': 1.81.0
       '@oxlint/binding-win32-x64-msvc': 1.81.0
 
+  parsimmon@1.18.1: {}
+
   path-browserify@1.0.1: {}
 
   path-parse@1.0.7:
@@ -3296,6 +3354,8 @@ snapshots:
       confbox: 0.3.0
       exsolve: 1.1.1
       pathe: 2.0.3
+
+  pluralize@8.0.0: {}
 
   postcss@8.5.27:
     dependencies:

--- a/src/formatter/dbml.test.ts
+++ b/src/formatter/dbml.test.ts
@@ -1,3 +1,4 @@
+import { Parser } from "@dbml/core";
 import { describe, it, expect } from "vitest";
 import { DbmlFormatter } from "./dbml";
 import type { IntermediateSchema } from "../types";
@@ -456,6 +457,82 @@ describe("DbmlFormatter", () => {
       expect(dbml).toContain(
         'Ref: "posts"."author_id" > "users"."id" [delete: cascade, update: set null]',
       );
+    });
+
+    it("should parenthesize both sides of a composite foreign key", () => {
+      // A subtype table keyed on (part_id, category) that references the
+      // parent's composite unique (id, category). DBML requires
+      // `"table".("a", "b")` for a multi-column side.
+      const schema: IntermediateSchema = {
+        databaseType: "postgresql",
+        tables: [
+          {
+            name: "part",
+            columns: [
+              {
+                name: "id",
+                type: "text",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "category",
+                type: "text",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [
+              { name: "part_id_category_key", type: "unique", columns: ["id", "category"] },
+            ],
+          },
+          {
+            name: "part_cpu",
+            columns: [
+              {
+                name: "part_id",
+                type: "text",
+                nullable: false,
+                primaryKey: true,
+                unique: false,
+              },
+              {
+                name: "category",
+                type: "text",
+                nullable: false,
+                primaryKey: false,
+                unique: false,
+              },
+            ],
+            indexes: [],
+            constraints: [],
+          },
+        ],
+        relations: [
+          {
+            fromTable: "part_cpu",
+            fromColumns: ["part_id", "category"],
+            toTable: "part",
+            toColumns: ["id", "category"],
+            type: "many-to-one",
+            onDelete: "CASCADE",
+          },
+        ],
+        enums: [],
+      };
+
+      const formatter = new DbmlFormatter();
+      const dbml = formatter.format(schema);
+
+      expect(dbml).toContain(
+        'Ref: "part_cpu".("part_id", "category") > "part".("id", "category") [delete: cascade]',
+      );
+      // The reference parser is the arbiter: without the parentheses it
+      // rejects the file, so this is what proves the output is valid DBML.
+      expect(() => new Parser().parse(dbml, "dbml")).not.toThrow();
     });
 
     it("should format PostgreSQL enums", () => {

--- a/src/formatter/dbml.test.ts
+++ b/src/formatter/dbml.test.ts
@@ -872,6 +872,8 @@ describe("DbmlFormatter", () => {
       { input: "time(3) with time zone", expected: "timetz(3)" },
       { input: "timestamp", expected: "timestamp" },
       { input: "timestamp(3)", expected: "timestamp(3)" },
+      { input: "double precision", expected: "float8" },
+      { input: "real", expected: "real" },
     ])("should normalize '$input' to '$expected'", ({ input, expected }) => {
       const schema: IntermediateSchema = {
         databaseType: "postgresql",
@@ -899,6 +901,8 @@ describe("DbmlFormatter", () => {
       const dbml = formatter.format(schema);
 
       expect(dbml).toContain(`"col" ${expected}`);
+      // Every normalized type must be a single token the reference parser accepts.
+      expect(() => new Parser().parse(dbml, "dbml")).not.toThrow();
     });
   });
 

--- a/src/formatter/dbml.ts
+++ b/src/formatter/dbml.ts
@@ -285,8 +285,8 @@ export class DbmlFormatter implements OutputFormatter {
    * Format a relation definition to DBML Ref
    */
   private formatRelation(dbml: DbmlBuilder, relation: RelationDefinition): void {
-    const from = `${this.escapeName(relation.fromTable)}.${relation.fromColumns.map((c) => this.escapeName(c)).join(", ")}`;
-    const to = `${this.escapeName(relation.toTable)}.${relation.toColumns.map((c) => this.escapeName(c)).join(", ")}`;
+    const from = this.formatRelationSide(relation.fromTable, relation.fromColumns);
+    const to = this.formatRelationSide(relation.toTable, relation.toColumns);
     const type = this.getRelationType(relation.type);
 
     let refLine = `Ref: ${from} ${type} ${to}`;
@@ -304,6 +304,19 @@ export class DbmlFormatter implements OutputFormatter {
     }
 
     dbml.line(refLine);
+  }
+
+  /**
+   * Format one side of a Ref
+   *
+   * A single column is `"table"."column"`; a composite key is
+   * `"table".("a", "b")` — DBML requires the parentheses whenever a side
+   * has more than one column.
+   */
+  private formatRelationSide(table: string, columns: string[]): string {
+    const escaped = columns.map((c) => this.escapeName(c));
+    const columnList = escaped.length > 1 ? `(${escaped.join(", ")})` : escaped.join(", ");
+    return `${this.escapeName(table)}.${columnList}`;
   }
 
   /**

--- a/src/formatter/dbml.ts
+++ b/src/formatter/dbml.ts
@@ -338,9 +338,9 @@ export class DbmlFormatter implements OutputFormatter {
   /**
    * Normalize SQL type for DBML compatibility
    *
-   * Converts types with "with time zone" suffix to their short form
-   * (e.g., "timestamp(3) with time zone" -> "timestamptz(3)")
-   * because DBML parsers cannot handle the multi-word suffix.
+   * Converts multi-word types to their one-word aliases because DBML's type
+   * grammar takes a single token: "timestamp(3) with time zone" ->
+   * "timestamptz(3)", "double precision" -> "float8" (PostgreSQL's own alias).
    */
   private normalizeType(type: string): string {
     return type
@@ -349,7 +349,8 @@ export class DbmlFormatter implements OutputFormatter {
       )
       .replace(/^(time)\s*(\([^)]*\))?\s+with time zone$/i, (_match, _base, precision) =>
         precision ? `timetz${precision}` : "timetz",
-      );
+      )
+      .replace(/^double\s+precision$/i, "float8");
   }
 
   /**


### PR DESCRIPTION
Two independent bugs make the generated `.dbml` unparseable by `@dbml/core` (the parser behind dbdiagram.io), so the file cannot be pasted into dbdiagram.io. One commit each.

### 1. Composite foreign keys lose their parentheses

```
Ref: "part_cpu"."part_id", "category" > "part"."id", "category"
```

The DBML grammar reads that as one column followed by stray tokens. The spec's form for a multi-column side is `"part_cpu".("part_id", "category")` ([Relationships & Foreign Key Definitions](https://dbml.dbdiagram.io/docs/#relationships-foreign-key-definitions)). Single-column refs were already correct, and the index formatter in the same file already wraps its column lists — `formatRelation` just never met a composite key. Fixed by wrapping a side in parentheses when it has more than one column.

### 2. `double precision` is two tokens

DBML's type grammar takes one. Handled the way `timestamp with time zone` → `timestamptz` already is: `double precision` → `float8`, PostgreSQL's own alias, so the DBML still means what the schema meant.

### Tests

Both tests assert that the output **parses with `@dbml/core`**, not only that the string matches — a string assertion would have passed for the old output too. `@dbml/core` is added as a devDependency for that; if you'd rather not carry it, the string assertions stand on their own and the `Parser` lines can be dropped.

Reproduced from a Drizzle schema with one composite `foreignKey()` and one `doublePrecision()` column: before, `@dbml/core` rejects the output at the first `Ref:`; after, it accepts it.

`pnpm format && pnpm lint && pnpm typecheck && pnpm test:run`, `pnpm build && pnpm test:integration`, and `pnpm generate:examples` (no changes) all pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected DBML formatting for composite foreign keys by ensuring both sides are properly parenthesized.
  - Improved type normalization for multi-word aliases, including converting `double precision` to `float8`.
  - Added validation to ensure generated DBML remains compatible with the reference parser.

- **Tests**
  - Expanded coverage for composite relationships and normalized database type names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->